### PR TITLE
fix filter for hierarchy

### DIFF
--- a/core/src/main/java/org/eclipse/daanse/rolap/common/SqlTupleReader.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/SqlTupleReader.java
@@ -1418,6 +1418,8 @@ public TupleList readTuples(
         if ( whichSelect == WhichSelect.ONLY ) {
           sqlQuery.addOrderBy(
             ordinalSql, orderByAlias, true, false, true, true );
+          sqlQuery.addOrderBy(
+                  keySql, keyAlias, true, false, true, true );
         }
       } else {
         if ( whichSelect == WhichSelect.ONLY ) {


### PR DESCRIPTION
Signed-off-by: dbulahov <bulahovdenis@gmail.com>

### What does this PR do?
this pr fix ordering for members. 
cache worked incorrect for old ordering.
hierarchy had 3 levels:

building level: had column = building and orderColumn = building_order 
room level: had column = room
comment level: had column = comment

old ordering:   order by building_order, room, comment

b_order, building1, room1, comment
b_order, building2, room1, comment
b_order, building1, room2, comment
b_order, building2, room2, comment

in this case we had only first record for building1
`b_order, building1, room1, comment`
______________________________________________________________
new ordering:   order by building_order, building, room, comment (was add building.  ) 

b_order, building1, room1, comment
b_order, building1, room2, comment
b_order, building2, room1, comment
b_order, building2, room2, comment

in this case we had two records for building1 in cache:
b_order, building1, room1, comment
b_order, building1, room2, comment


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Daanse
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
