### PR TITLE
Migrate rolap to CWM mapping model

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,6 +41,12 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.cwm.util</artifactId>
+      <version>${revision}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
       <artifactId>org.eclipse.daanse.olap.common</artifactId>
       <version>${revision}</version>
     </dependency>

--- a/core/src/main/java/org/eclipse/daanse/rolap/aggregator/extra/BitAggAggregator.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/aggregator/extra/BitAggAggregator.java
@@ -25,11 +25,11 @@ import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 public class BitAggAggregator implements Aggregator {
 
     private boolean not;
-    private org.eclipse.daanse.rolap.mapping.model.BitAggType bitAggType;
+    private org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggType bitAggType;
     private Dialect dialect;
 
     //
-    public BitAggAggregator(boolean not, org.eclipse.daanse.rolap.mapping.model.BitAggType bitAggType, Dialect dialect) {
+    public BitAggAggregator(boolean not, org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggType bitAggType, Dialect dialect) {
         this.not = not;
         this.bitAggType = bitAggType;
         this.dialect = dialect;
@@ -53,9 +53,9 @@ public class BitAggAggregator implements Aggregator {
     @Override
     public StringBuilder getExpression(CharSequence operand) {
         return switch (bitAggType) {
-        case org.eclipse.daanse.rolap.mapping.model.BitAggType.AND -> and(operand);
-        case org.eclipse.daanse.rolap.mapping.model.BitAggType.OR -> or(operand);
-        case org.eclipse.daanse.rolap.mapping.model.BitAggType.XOR -> xor(operand);
+        case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggType.AND -> and(operand);
+        case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggType.OR -> or(operand);
+        case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggType.XOR -> xor(operand);
         };
     }
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/aggregator/extra/PercentileAggregator.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/aggregator/extra/PercentileAggregator.java
@@ -21,8 +21,8 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.rolap.element.RolapColumn;
-import org.eclipse.daanse.rolap.mapping.model.PercentType;
-import org.eclipse.daanse.rolap.mapping.model.SortingDirection;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.PercentType;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.SortingDirection;
 
 
 public class PercentileAggregator implements Aggregator {

--- a/core/src/main/java/org/eclipse/daanse/rolap/api/RolapContext.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/api/RolapContext.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import org.eclipse.daanse.olap.api.Context;
 import org.eclipse.daanse.olap.api.connection.Connection;
 import org.eclipse.daanse.rolap.api.aggmatch.AggregationMatchRulesSupplier;
-import org.eclipse.daanse.rolap.mapping.model.Catalog;
+import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 
 public interface RolapContext extends Context<Connection> {
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/MeasureFinder.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/MeasureFinder.java
@@ -113,13 +113,13 @@ public class MeasureFinder extends MdxVisitorImpl
                         virtualCube.getMeasuresHierarchy(),
                         Util.<RolapMember>cast(measuresFound))));
 
-            org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember =
+            org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember =
                 schema.lookupMappingCalculatedMember(
                     calcMember.getName(),
                     baseCube.getName());
             virtualCube.createCalcMembersAndNamedSets(
                 Collections.singletonList(mappingCalcMember),
-                Collections.<org.eclipse.daanse.rolap.mapping.model.NamedSet>emptyList(),
+                Collections.<org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet>emptyList(),
                 new ArrayList<>(),
                 virtualCube,
                 false);

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/RolapStatisticsCache.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/RolapStatisticsCache.java
@@ -60,14 +60,14 @@ public class RolapStatisticsCache {
     }
 
     public long getRelationCardinality(
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         String alias,
         long approxRowCount)
     {
         if (approxRowCount >= 0) {
             return approxRowCount;
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
             return getTableCardinality(
                 null, table.getTable());
         } else {
@@ -80,9 +80,9 @@ public class RolapStatisticsCache {
 
     private long getTableCardinality(
         String catalog,
-        org.eclipse.daanse.rolap.mapping.model.Table table)
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table)
     {
-    	String schema = table.getSchema() != null ? table.getSchema().getName() : null;
+    	String schema = table.getNamespace() != null ? table.getNamespace().getName() : null;
         final List<String> key = Arrays.asList(catalog, schema, table.getName());
         long rowCount = -1;
         if (tableMap.containsKey(key)) {
@@ -145,14 +145,14 @@ public class RolapStatisticsCache {
     }
 
     public long getColumnCardinality(
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         SqlExpression expression,
         long approxCardinality)
     {
         if (approxCardinality >= 0) {
             return approxCardinality;
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table
             && expression instanceof org.eclipse.daanse.rolap.element.RolapColumn column)
         {
             return getColumnCardinality(
@@ -170,10 +170,10 @@ public class RolapStatisticsCache {
 
     private long getColumnCardinality(
         String catalog,
-        org.eclipse.daanse.rolap.mapping.model.Table table,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table,
         String column)
     {
-    	String schema = table.getSchema() != null ? table.getSchema().getName() : null;
+    	String schema = table.getNamespace() != null ? table.getNamespace().getName() : null;
         final List<String> key = Arrays.asList(catalog, schema, table.getName(), column);
         long rowCount = -1;
         if (columnMap.containsKey(key)) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/RolapUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/RolapUtil.java
@@ -42,6 +42,13 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
 
+import org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Row;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RowSet;
+import org.eclipse.daanse.cwm.util.resource.relational.ColumnSets;
+import org.eclipse.daanse.cwm.util.resource.relational.RowSets;
+import org.eclipse.daanse.cwm.util.resource.relational.Rows;
 import org.eclipse.daanse.jdbc.db.dialect.api.Dialect;
 import org.eclipse.daanse.jdbc.db.dialect.api.type.BestFitColumnType;
 import org.eclipse.daanse.olap.api.Context;
@@ -75,6 +82,7 @@ import org.eclipse.daanse.rolap.util.ClassResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 /**
  * Utility methods for classes in the mondrian.rolap package.
  *
@@ -469,77 +477,88 @@ public class RolapUtil {
         return bestMatch;
     }
 
-    public static org.eclipse.daanse.rolap.mapping.model.RelationalQuery convertInlineTableToRelation(
-    		org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTable,
+    public static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource convertInlineTableToRelation(
+    		org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTable,
         final Dialect dialect)
     {
+        List<Column> cols = ColumnSets.columns(inlineTable.getTable());
+        List<String> columnNames = cols.stream().map(Column::getName).toList();
+        List<String> columnTypes = cols.stream().map(c -> c.getType().getName()).toList();
+        final int columnCount = cols.size();
 
-        final int columnCount = inlineTable.getTable().getColumns().size();
-        List<String> columnNames = new ArrayList<>();
-        List<String> columnTypes = new ArrayList<>();
-        for (int i = 0; i < columnCount; i++) {
-            columnNames.add(inlineTable.getTable().getColumns().get(i).getName());
-            columnTypes.add(inlineTable.getTable().getColumns().get(i).getType().getLiteral());
-        }
         List<String[]> valueList = new ArrayList<>();
-        for (org.eclipse.daanse.rolap.mapping.model.Row row : inlineTable.getTable().getRows()) {
+        RowSet extent = inlineTable.getTable().getExtent();
+        List<Row> rows = extent == null ? List.of() : RowSets.rows(extent);
+        for (Row row : rows) {
             String[] values = new String[columnCount];
-            for (org.eclipse.daanse.rolap.mapping.model.RowValue value : row.getRowValues()) {
-                final int columnOrdinal = columnNames.indexOf(value.getColumn().getName());
+            for (DataSlot value : Rows.slots(row)) {
+                Column col = (Column) value.getFeature();
+                final int columnOrdinal = columnNames.indexOf(col.getName());
                 if (columnOrdinal < 0) {
                     throw Util.newError(
-                        new StringBuilder("Unknown column '").append(value.getColumn().getName()).append("'").toString());
+                        new StringBuilder("Unknown column '").append(col.getName()).append("'").toString());
                 }
-                values[columnOrdinal] = value.getValue();
+                values[columnOrdinal] = value.getDataValue();
             }
             valueList.add(values);
         }
-        org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view = RolapMappingFactory.eINSTANCE.createSqlSelectQuery();
+        org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view = SourceFactory.eINSTANCE.createSqlSelectSource();
         view.setAlias(getAlias(inlineTable));
-        
-        org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+
+        org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
         sqlStatement.getDialects().add("generic");
         sqlStatement.setSql(dialect.generateInline(columnNames, columnTypes, valueList).toString());
-        
-        org.eclipse.daanse.rolap.mapping.model.SqlView sqlView = RolapMappingFactory.eINSTANCE.createSqlView();
-        sqlView.getSqlStatements().add(sqlStatement);
+
+        org.eclipse.daanse.rolap.mapping.model.database.relational.DialectSqlView sqlView = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createDialectSqlView();
+        sqlView.getDialectStatements().add(sqlStatement);
 
         view.setSql(sqlView);
 
         return view;
     }
 
-    public static org.eclipse.daanse.rolap.mapping.model.RelationalQuery convertInlineTableToRelation(
-    		org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTable,
+    public static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource convertInlineTableToRelation(
+    		org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTable,
             final Dialect dialect, List<String> orderColumns)
         {
             List<String> columnNames = new ArrayList<>();
             List<String> columnTypes = new ArrayList<>();
             
-            List<? extends org.eclipse.daanse.rolap.mapping.model.Column> columns = inlineTable.getTable().getColumns().stream().sorted(Comparator.comparingInt(o -> orderColumns.indexOf(o.getName()))).toList();
+            List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> columns = ColumnSets
+                    .columnStream(inlineTable.getTable())
+                    .sorted(Comparator.comparingInt(o -> orderColumns.indexOf(o.getName()))).toList();
             
-            for (org.eclipse.daanse.rolap.mapping.model.Column columnMapping : columns) {
+            for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Column columnMapping : columns) {
             		columnNames.add(columnMapping.getName());
-            		columnTypes.add(columnMapping.getType().getLiteral());
+            		columnTypes.add(columnMapping.getType().getName());
             }
             List<String[]> valueList = new ArrayList<>();
-            for (org.eclipse.daanse.rolap.mapping.model.Row row : inlineTable.getTable().getRows()) {
+            List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Row> rows =
+                inlineTable.getTable().getExtent() == null ? java.util.List.of()
+                    : inlineTable.getTable().getExtent().getOwnedElement().stream()
+                        .filter(org.eclipse.daanse.cwm.model.cwm.resource.relational.Row.class::isInstance)
+                        .map(org.eclipse.daanse.cwm.model.cwm.resource.relational.Row.class::cast).toList();
+            for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Row row : rows) {
                 List<String> values = new ArrayList<>();
-                List<? extends org.eclipse.daanse.rolap.mapping.model.RowValue> rowValues = row.getRowValues().stream().sorted(Comparator.comparingInt(v -> orderColumns.indexOf(v.getColumn().getName()))).toList();
-                for (org.eclipse.daanse.rolap.mapping.model.RowValue rowValue : rowValues) {
-                	values.add(rowValue.getValue());
+                List<? extends org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot> rowValues = row.getSlot().stream()
+                    .filter(org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot.class::isInstance)
+                    .map(org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot.class::cast)
+                    .sorted(Comparator.comparingInt(v -> orderColumns.indexOf(((org.eclipse.daanse.cwm.model.cwm.resource.relational.Column) v.getFeature()).getName())))
+                    .toList();
+                for (org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot rowValue : rowValues) {
+                	values.add(rowValue.getDataValue());
                 }
                 valueList.add(values.toArray(new String[0]));
             }
             
-            org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+            org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
             sqlStatement.getDialects().add("generic");
             sqlStatement.setSql(dialect.generateInline(columnNames, columnTypes, valueList).toString());
             
-            org.eclipse.daanse.rolap.mapping.model.SqlView sqlView = RolapMappingFactory.eINSTANCE.createSqlView();
-            sqlView.getSqlStatements().add(sqlStatement);
+            org.eclipse.daanse.rolap.mapping.model.database.relational.DialectSqlView sqlView = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createDialectSqlView();
+            sqlView.getDialectStatements().add(sqlStatement);
             
-            org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view = RolapMappingFactory.eINSTANCE.createSqlSelectQuery();
+            org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view = SourceFactory.eINSTANCE.createSqlSelectSource();
             view.setAlias(getAlias(inlineTable));
             view.setSql(sqlView);
             
@@ -630,13 +649,13 @@ public class RolapUtil {
      * @return the rolap star key
      */
     public static List<String> makeRolapStarKey(
-        final org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact)
+        final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact)
     {
       List<String> rlStarKey = new ArrayList<>();
       rlStarKey.add(getAlias(fact));
       // Add SQL filter to the key
-      if (fact instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
-        org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlWhere = table.getSqlWhereExpression();
+      if (fact instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
+        org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlWhere = table.getSqlWhereExpression();
         String sql = sqlWhere != null ? sqlWhere.getSql() : null;
         if (sql != null && !sql.isBlank()) {
           rlStarKey.addAll(sqlWhere.getDialects());

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/SqlStatement.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/SqlStatement.java
@@ -402,8 +402,17 @@ public class SqlStatement implements SqlStatementI {
    * @return Runtime exception
    */
   public RuntimeException handle( Throwable e ) {
+    // Use the high-level operation description from the execution metadata
+    // when available (e.g. "while building member cache"), falling back to a
+    // generic "executing SQL" otherwise. Tests like
+    // SchemaTest#testHierarchyTableNotFound match against the metadata phrase.
+    String description = (executionContext != null
+            && executionContext.metadata() != null
+            && executionContext.metadata().message() != null)
+        ? executionContext.metadata().message()
+        : "executing SQL";
     RuntimeException runtimeException =
-      Util.newError( e, new StringBuilder("executing SQL").append("; sql=[").append(sql).append("]").toString() );
+      Util.newError( e, new StringBuilder(description).append("; sql=[").append(sql).append("]").toString() );
     try {
       close();
     } catch (RuntimeException ignored) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/Utils.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/Utils.java
@@ -27,26 +27,26 @@ public class Utils {
     private Utils() {
     }
 
-    public static boolean equalsQuery(org.eclipse.daanse.rolap.mapping.model.Query relation, org.eclipse.daanse.rolap.mapping.model.Query q2) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery t1 && q2 instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery t2) {
+    public static boolean equalsQuery(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation, org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource q2) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource t1 && q2 instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource t2) {
             return t1.getTable() != null && t2.getTable() != null &&  t1.getTable().getName().equals(t2.getTable().getName()) &&
                 Objects.equals(t1.getAlias(), t2.getAlias()) &&
-                equalsSchema(t1.getTable().getSchema(), t2.getTable().getSchema());
+                equalsSchema((org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema) t1.getTable().getNamespace(), (org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema) t2.getTable().getNamespace());
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery s1 && q2 instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery s2) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource s1 && q2 instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource s2) {
             if (!Objects.equals(s1.getAlias(), s2.getAlias())) {
                 return false;
             }
             if (s1.getSql() == null || s2.getSql() == null ||
-            	s1.getSql().getSqlStatements() == null || s2.getSql().getSqlStatements() == null ||
-                s1.getSql().getSqlStatements().size() != s2.getSql().getSqlStatements().size()) {
+            	s1.getSql().getDialectStatements() == null || s2.getSql().getDialectStatements() == null ||
+                s1.getSql().getDialectStatements().size() != s2.getSql().getDialectStatements().size()) {
                 return false;
             }
-            for (int i = 0; i < s1.getSql().getSqlStatements().size(); i++) {
-                String statement1 = s1.getSql().getSqlStatements().get(i).getSql();
-                String statement2 = s2.getSql().getSqlStatements().get(i).getSql();
-                List<String> dialects1 = s1.getSql().getSqlStatements().get(i).getDialects();
-                List<String> dialects2 = s2.getSql().getSqlStatements().get(i).getDialects();
+            for (int i = 0; i < s1.getSql().getDialectStatements().size(); i++) {
+                String statement1 = s1.getSql().getDialectStatements().get(i).getSql();
+                String statement2 = s2.getSql().getDialectStatements().get(i).getSql();
+                List<String> dialects1 = s1.getSql().getDialectStatements().get(i).getDialects();
+                List<String> dialects2 = s2.getSql().getDialectStatements().get(i).getDialects();
 
                 if (!Objects.equals(statement1, statement2)) {
                     return false;
@@ -63,13 +63,13 @@ public class Utils {
             }
             return true;
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery it1 && q2 instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery it2) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource it1 && q2 instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource it2) {
             return it1.getAlias() != null && it1.getAlias().equals(it2.getAlias()); //old implementation
         }
         return false;
     }
 
-	private static boolean equalsSchema(org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema1, org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema2) {
+	private static boolean equalsSchema(org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema1, org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema2) {
         if (schema1 == null && schema2 == null) {
             return true;
         }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/AggGen.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/AggGen.java
@@ -185,7 +185,7 @@ public class AggGen {
      * create lost create and insert commands.
      */
     private void init() {
-    org.eclipse.daanse.rolap.mapping.model.DatabaseSchema dbschema=	((RolapContext) star.getContext()).getCatalogMapping().getDbschemas().getFirst();
+    org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema dbschema=	((RolapContext) star.getContext()).getCatalogMapping().getDbschemas().getFirst();
         JdbcSchema db =   new JdbcSchema(dbschema);
 
         JdbcSchema.Table factTable = getTable(db, getFactTableName());

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/AggStar.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/AggStar.java
@@ -829,11 +829,11 @@ public class AggStar {
 
         /** The name of the table in the database. */
         private final String name;
-        private final org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation;
+        private final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation;
         protected final List<Level> levels = new ArrayList<>();
         protected List<DimTable> children;
 
-        Table(final String name, final org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
+        Table(final String name, final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
             this.name = name;
             this.relation = relation;
             this.children = Collections.emptyList();
@@ -864,7 +864,7 @@ public class AggStar {
         public abstract boolean hasJoinCondition();
         public abstract Table.JoinCondition getJoinCondition();
 
-        public org.eclipse.daanse.rolap.mapping.model.RelationalQuery getRelation() {
+        public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getRelation() {
             return relation;
         }
 
@@ -954,7 +954,7 @@ public class AggStar {
             final Usage usage)
         {
             String tableName = rTable.getAlias();
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery relationInner = rTable.getRelation();
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationInner = rTable.getRelation();
             RolapStar.Condition rjoinCondition = rTable.getJoinCondition();
             SqlExpression rleft = rjoinCondition.getLeft();
             final SqlExpression rright;
@@ -1203,7 +1203,7 @@ public class AggStar {
 
         FactTable(
             final String name,
-            final org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
+            final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
             final int totalColumnSize,
             final long numberOfRows)
         {
@@ -1612,7 +1612,7 @@ public class AggStar {
         DimTable(
             final Table parent,
             final String name,
-            final org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
+            final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
             final JoinCondition joinCondition)
         {
             super(name, relation);

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/AggTableManager.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/AggTableManager.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 /**
  * Manages aggregate tables.
  *
@@ -181,14 +182,14 @@ public class AggTableManager {
 //            connectionProps.aggregateScanCatalog();
             Optional<String> oAaggregateScanSchema=    connectionProps.aggregateScanSchema();
 
-			List<? extends org.eclipse.daanse.rolap.mapping.model.DatabaseSchema> schemas = ((RolapContext) context).getCatalogMapping()
+			List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema> schemas = ((RolapContext) context).getCatalogMapping()
 					.getDbschemas();
 
-			org.eclipse.daanse.rolap.mapping.model.DatabaseSchema databaseSchema = schemas.getFirst();
+			org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema databaseSchema = schemas.getFirst();
 			if (oAaggregateScanSchema.isPresent()) {
 				String aaggregateScanSchema = oAaggregateScanSchema.get();
 
-				for (org.eclipse.daanse.rolap.mapping.model.DatabaseSchema dbs : schemas) {
+				for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema dbs : schemas) {
 					if (dbs.getName().equals(aaggregateScanSchema)) {
 						databaseSchema = dbs;
 						break;
@@ -233,7 +234,7 @@ public class AggTableManager {
 
                     for (JdbcSchema.Table dbTable : db.getTables()) {
                         String name = dbTable.getName();
-                        org.eclipse.daanse.rolap.mapping.model.Table t = dbTable.getModelTable();
+                        org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet t = dbTable.getModelTable();
                         // Do the catalog schema aggregate excludes, exclude
                         // this table name.
                         if (ExplicitRules.excludeTable(name, aggGroups)) {
@@ -275,7 +276,7 @@ public class AggTableManager {
                         if (makeAggStar) {
                             dbTable.setTableUsageType(
                                 JdbcSchema.TableUsageType.AGG);
-                            org.eclipse.daanse.rolap.mapping.model.TableQuery q = RolapMappingFactory.eINSTANCE.createTableQuery();
+                            org.eclipse.daanse.rolap.mapping.model.database.source.TableSource q = SourceFactory.eINSTANCE.createTableSource();
                             q.setTable(t);
                             dbTable.table = q;
                             AggStar aggStar = AggStar.makeAggStar(
@@ -350,18 +351,18 @@ public class AggTableManager {
 
             dbFactTable.setTableUsageType(JdbcSchema.TableUsageType.FACT);
 
-            org.eclipse.daanse.rolap.mapping.model.Query relation =
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation =
                 star.getFactTable().getRelation();
             
-            List<? extends org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint> tableHints = null;
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint> tableHints = null;
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
                 tableHints = PojoUtil.getOptimizationHints(table.getOptimizationHints());
             }
             
-            org.eclipse.daanse.rolap.mapping.model.Table t = dbFactTable.getModelTable();
+            org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet t = dbFactTable.getModelTable();
 
             String alias = null;
-            org.eclipse.daanse.rolap.mapping.model.TableQuery q = RolapMappingFactory.eINSTANCE.createTableQuery();
+            org.eclipse.daanse.rolap.mapping.model.database.source.TableSource q = SourceFactory.eINSTANCE.createTableSource();
             q.setAlias(alias);
             q.setTable(t);
             q.getOptimizationHints().addAll(tableHints);

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/ExplicitRecognizer.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/ExplicitRecognizer.java
@@ -178,7 +178,7 @@ class ExplicitRecognizer extends Recognizer {
 
                 if (factColumn.hasUsage(JdbcSchema.UsageType.FOREIGN_KEY)) {
                     // What we've got here is a measure based upon a foreign key
-                	org.eclipse.daanse.rolap.mapping.model.Column aggFK =
+                	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column aggFK =
                         getTableDef().getAggregateFK(factColumn.getName());
                     // OK, not a lost dimension
                     if (aggFK != null) {
@@ -254,7 +254,7 @@ class ExplicitRecognizer extends Recognizer {
         final JdbcSchema.Table.Column.Usage factUsage)
     {
         JdbcSchema.Table.Column factColumn = factUsage.getColumn();
-        org.eclipse.daanse.rolap.mapping.model.Column aggFK = getTableDef().getAggregateFK(factColumn.getName());
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column aggFK = getTableDef().getAggregateFK(factColumn.getName());
 
         // OK, a lost dimension
         if (aggFK == null) {
@@ -358,7 +358,7 @@ class ExplicitRecognizer extends Recognizer {
     }
 
     private Column getColumn(
-    		org.eclipse.daanse.rolap.mapping.model.Column columnName, Map<String, Column> aggTableColumnMap)
+    		org.eclipse.daanse.cwm.model.cwm.resource.relational.Column columnName, Map<String, Column> aggTableColumnMap)
     {
         if (columnName == null) {
             return null;
@@ -367,10 +367,10 @@ class ExplicitRecognizer extends Recognizer {
     }
 
     private Map<String, Column> getProperties(
-        Map<String, org.eclipse.daanse.rolap.mapping.model.Column> properties, Map<String, Column> columnMap)
+        Map<String, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> properties, Map<String, Column> columnMap)
     {
         Map<String, Column> map = new HashMap<>();
-        for (Map.Entry<String, org.eclipse.daanse.rolap.mapping.model.Column> entry : properties.entrySet()) {
+        for (Map.Entry<String, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> entry : properties.entrySet()) {
             map.put(entry.getKey(), getColumn(entry.getValue(), columnMap));
         }
         return Collections.unmodifiableMap(map);
@@ -506,8 +506,8 @@ class ExplicitRecognizer extends Recognizer {
 	protected String getFactCountColumnName
             (final JdbcSchema.Table.Column.Usage aggUsage) {
         String measureName = aggUsage.getColumn().getName();
-        Map<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column> measuresFactCount = tableDef.getMeasuresFactCount();
-        Optional<Map.Entry<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column>> op = measuresFactCount.entrySet()
+        Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> measuresFactCount = tableDef.getMeasuresFactCount();
+        Optional<Map.Entry<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column>> op = measuresFactCount.entrySet()
         		.stream().filter(e -> e.getKey().getName().equals(measureName)).findAny();
         String factCountColumnName;
         if (op.isPresent() && !Util.isEmpty(op.get().getValue().getName())) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/ExplicitRules.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/ExplicitRules.java
@@ -65,6 +65,7 @@ import org.eclipse.daanse.rolap.recorder.MessageRecorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationFactory;
 /**
  * A class containing a RolapCube's Aggregate tables exclude/include
  * criteria.
@@ -127,26 +128,26 @@ public class ExplicitRules {
          */
         public static ExplicitRules.Group make(
             final RolapCube cube,
-            final org.eclipse.daanse.rolap.mapping.model.PhysicalCube xmlCube)
+            final org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube xmlCube)
         {
             Group group = new Group(cube);
 
-            org.eclipse.daanse.rolap.mapping.model.Query relation = xmlCube.getQuery();
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = xmlCube.getQuery();
 
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
-                List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationExclude> aggExcludes =
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
+                List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude> aggExcludes =
                     table.getAggregationExcludes();
                 if (aggExcludes != null) {
-                    for (org.eclipse.daanse.rolap.mapping.model.AggregationExclude aggExclude : aggExcludes) {
+                    for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude aggExclude : aggExcludes) {
                         Exclude exclude =
                             ExplicitRules.make(aggExclude);
                         group.addExclude(exclude);
                     }
                 }
-                List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationTable> aggTables =
+                List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable> aggTables =
                     table.getAggregationTables();
                 if (aggTables != null) {
-                    for (org.eclipse.daanse.rolap.mapping.model.AggregationTable aggTable : aggTables) {
+                    for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable aggTable : aggTables) {
                         TableDef tableDef = TableDef.make(aggTable, group);
                         group.addTableDef(tableDef);
                     }
@@ -266,7 +267,7 @@ public class ExplicitRules {
          */
         public String getTableName() {
             RolapStar.Table table = getStar().getFactTable();
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation = table.getRelation();
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = table.getRelation();
             return getAlias(relation);
         }
 
@@ -278,9 +279,9 @@ public class ExplicitRules {
             String schema = null;
 
             RolapStar.Table table = getStar().getFactTable();
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation = table.getRelation();
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = table.getRelation();
 
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mtable) {
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mtable) {
                 schema = mtable.getTable().getName();
             }
             return schema;
@@ -337,7 +338,7 @@ public class ExplicitRules {
         }
     }
 
-    private static Exclude make(final org.eclipse.daanse.rolap.mapping.model.AggregationExclude aggExclude) {
+    private static Exclude make(final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude aggExclude) {
         return (aggExclude.getName() != null)
             ? new ExcludeName(
                 aggExclude.getName(),
@@ -546,14 +547,14 @@ public class ExplicitRules {
          * which is either a NameTableDef or PatternTableDef.
          */
         static ExplicitRules.TableDef make(
-            final org.eclipse.daanse.rolap.mapping.model.AggregationTable aggTable,
+            final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable aggTable,
             final ExplicitRules.Group group)
         {
-            return (aggTable instanceof org.eclipse.daanse.rolap.mapping.model.AggregationName aggName)
+            return (aggTable instanceof org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName aggName)
                 ? ExplicitRules.NameTableDef.make(aggName, group)
                 : (ExplicitRules.TableDef)
                 ExplicitRules.PatternTableDef.make(
-                    (org.eclipse.daanse.rolap.mapping.model.AggregationPattern) aggTable, group);
+                    (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationPattern) aggTable, group);
         }
 
         /**
@@ -564,23 +565,23 @@ public class ExplicitRules {
          */
         private static void add(
             final ExplicitRules.TableDef tableDef,
-            final org.eclipse.daanse.rolap.mapping.model.AggregationTable aggTable)
+            final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable aggTable)
         {
 
-            if (aggTable instanceof org.eclipse.daanse.rolap.mapping.model.AggregationName aggName) {
+            if (aggTable instanceof org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName aggName) {
                 tableDef.setFactCountColumn(
                     aggName.getAggregationFactCount().getColumn());
             }
-            if (aggTable instanceof org.eclipse.daanse.rolap.mapping.model.AggregationPattern aggPattern) {
+            if (aggTable instanceof org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationPattern aggPattern) {
                 tableDef.setFactCountColumn(
                     aggPattern.getAggregationFactCount().getColumn());
             }
 
 
             if (aggTable.getAggregationMeasureFactCounts() != null) {
-                Map<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column> measuresFactCount =
+                Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> measuresFactCount =
                         tableDef.getMeasuresFactCount();
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationMeasureFactCount measureFact
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasureFactCount measureFact
                         : aggTable.getAggregationMeasureFactCounts())
                 {
                     measuresFactCount.put
@@ -589,31 +590,31 @@ public class ExplicitRules {
                 }
             }
 
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationColumnName> ignores =
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationColumnName> ignores =
                 aggTable.getAggregationIgnoreColumns();
 
             if (ignores != null) {
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationColumnName ignore : ignores) {
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationColumnName ignore : ignores) {
                     tableDef.addIgnoreColumn(ignore.getColumn());
                 }
             }
 
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationForeignKey> fks = aggTable.getAggregationForeignKeys();
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationForeignKey> fks = aggTable.getAggregationForeignKeys();
             if (fks != null) {
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationForeignKey fk : fks) {
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationForeignKey fk : fks) {
                     tableDef.addFK(fk);
                 }
             }
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationMeasure> measures = aggTable.getAggregationMeasures();
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasure> measures = aggTable.getAggregationMeasures();
             if (measures != null) {
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationMeasure measure : measures) {
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasure measure : measures) {
                     addTo(tableDef, measure);
                 }
             }
 
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationLevel> levels = aggTable.getAggregationLevels();
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevel> levels = aggTable.getAggregationLevels();
             if (levels != null) {
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationLevel level : levels) {
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevel level : levels) {
                     addTo(tableDef, level);
                 }
             }
@@ -621,7 +622,7 @@ public class ExplicitRules {
 
         private static void addTo(
             final ExplicitRules.TableDef tableDef,
-            final org.eclipse.daanse.rolap.mapping.model.AggregationLevel aggLevel)
+            final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevel aggLevel)
         {
             if (aggLevel.getNameColumn() != null) {
                 handleNameColumn(aggLevel);
@@ -639,8 +640,8 @@ public class ExplicitRules {
         /**
          * nameColumn is mapped to the internal property $name
          */
-        private static void handleNameColumn(org.eclipse.daanse.rolap.mapping.model.AggregationLevel aggLevel) {
-        	org.eclipse.daanse.rolap.mapping.model.AggregationLevelProperty nameProp = RolapMappingFactory.eINSTANCE.createAggregationLevelProperty();
+        private static void handleNameColumn(org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevel aggLevel) {
+        	org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevelProperty nameProp = AggregationFactory.eINSTANCE.createAggregationLevelProperty();
         	nameProp.setName(StandardProperty.NAME.getName());
         	nameProp.setColumn(aggLevel.getNameColumn());
         	//TODO
@@ -649,7 +650,7 @@ public class ExplicitRules {
 
         private static void addTo(
             final ExplicitRules.TableDef tableDef,
-            final org.eclipse.daanse.rolap.mapping.model.AggregationMeasure aggMeasure)
+            final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasure aggMeasure)
         {
             addMeasureTo(
                 tableDef,
@@ -661,11 +662,11 @@ public class ExplicitRules {
         public static void addLevelTo(
             final TableDef tableDef,
             final String name,
-            final org.eclipse.daanse.rolap.mapping.model.Column columnName,
+            final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column columnName,
             final boolean collapsed,
-            List<org.eclipse.daanse.rolap.mapping.model.Column> ordinalColumns,
-            org.eclipse.daanse.rolap.mapping.model.Column captionColumn,
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationLevelProperty> properties)
+            List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> ordinalColumns,
+            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column captionColumn,
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevelProperty> properties)
         {
             Level level = tableDef.new Level(
                 name, columnName, collapsed, ordinalColumns, captionColumn,
@@ -676,7 +677,7 @@ public class ExplicitRules {
         public static void addMeasureTo(
             final ExplicitRules.TableDef tableDef,
             final String name,
-            final org.eclipse.daanse.rolap.mapping.model.Column column,
+            final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column,
             final String rollupType)
         {
             Measure measure = tableDef.new Measure(name, column, rollupType);
@@ -689,12 +690,12 @@ public class ExplicitRules {
          */
         class Level {
             private final String name;
-            private final org.eclipse.daanse.rolap.mapping.model.Column column;
+            private final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column;
             private final boolean collapsed;
             private RolapLevel rlevel;
-            private final List<org.eclipse.daanse.rolap.mapping.model.Column> ordinalColumns;
-            private final org.eclipse.daanse.rolap.mapping.model.Column captionColumn;
-            private final Map<String, org.eclipse.daanse.rolap.mapping.model.Column> properties;
+            private final List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> ordinalColumns;
+            private final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column captionColumn;
+            private final Map<String, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> properties;
             private final static String unknownLevelName =
                 "Context ''{0}'': The Hierarchy Level ''{1}'' does not have a Level named ''{2}''";
             private final static String badLevelNameFormat =
@@ -704,11 +705,11 @@ public class ExplicitRules {
 
             Level(
                 final String name,
-                final org.eclipse.daanse.rolap.mapping.model.Column column,
+                final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column,
                 final boolean collapsed,
-                List<org.eclipse.daanse.rolap.mapping.model.Column> ordinalColumns,
-                org.eclipse.daanse.rolap.mapping.model.Column captionColumn,
-                List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationLevelProperty> properties)
+                List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> ordinalColumns,
+                org.eclipse.daanse.cwm.model.cwm.resource.relational.Column captionColumn,
+                List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevelProperty> properties)
             {
                 this.name = name;
                 this.column = column;
@@ -718,11 +719,11 @@ public class ExplicitRules {
                 this.properties = makePropertyMap(properties);
             }
 
-            private Map<String, org.eclipse.daanse.rolap.mapping.model.Column> makePropertyMap(
-                List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationLevelProperty> properties)
+            private Map<String, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> makePropertyMap(
+                List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevelProperty> properties)
             {
-                Map<String, org.eclipse.daanse.rolap.mapping.model.Column> map = new HashMap<>();
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationLevelProperty prop : properties) {
+                Map<String, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> map = new HashMap<>();
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationLevelProperty prop : properties) {
                     map.put(prop.getName(), prop.getColumn());
                 }
                 return Collections.unmodifiableMap(map);
@@ -738,7 +739,7 @@ public class ExplicitRules {
             /**
              * Get the foreign key column name of the aggregate table.
              */
-            public org.eclipse.daanse.rolap.mapping.model.Column getColumn() {
+            public org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getColumn() {
                 return column;
             }
 
@@ -775,7 +776,7 @@ public class ExplicitRules {
                 msgRecorder.pushContextName("Level");
                 try {
                     String nameInner = getName();
-                    org.eclipse.daanse.rolap.mapping.model.Column columnInner = getColumn();
+                    org.eclipse.daanse.cwm.model.cwm.resource.relational.Column columnInner = getColumn();
                     checkAttributeString(msgRecorder, nameInner, "name");
                     checkAttributeString(msgRecorder, columnInner.getName(), "column");
 
@@ -850,15 +851,15 @@ public class ExplicitRules {
             }
 
 
-            public List<org.eclipse.daanse.rolap.mapping.model.Column> getOrdinalColumns() {
+            public List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> getOrdinalColumns() {
                 return ordinalColumns;
             }
 
-            public org.eclipse.daanse.rolap.mapping.model.Column getCaptionColumn() {
+            public org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getCaptionColumn() {
                 return captionColumn;
             }
 
-            public Map<String, org.eclipse.daanse.rolap.mapping.model.Column> getProperties() {
+            public Map<String, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> getProperties() {
                 return properties;
             }
         }
@@ -921,7 +922,7 @@ public class ExplicitRules {
         class Measure {
             private final String name;
             private String symbolicName;
-            private final org.eclipse.daanse.rolap.mapping.model.Column column;
+            private final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column;
             private final RollupType explicitRollupType;
             private RolapStar.Measure rolapMeasure;
             private final static String badMeasureName =
@@ -934,7 +935,7 @@ public class ExplicitRules {
 
             Measure(
                 final String name,
-                final org.eclipse.daanse.rolap.mapping.model.Column column, final String rollupType)
+                final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column, final String rollupType)
             {
                 this.name = name;
                 this.column = column;
@@ -960,7 +961,7 @@ public class ExplicitRules {
             /**
              * Get the aggregate table column name.
              */
-            public org.eclipse.daanse.rolap.mapping.model.Column getColumn() {
+            public org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getColumn() {
                 return column;
             }
 
@@ -988,7 +989,7 @@ public class ExplicitRules {
                 msgRecorder.pushContextName("Measure");
                 try {
                     String nameInner = getName();
-                    org.eclipse.daanse.rolap.mapping.model.Column column = getColumn();
+                    org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column = getColumn();
                     checkAttributeString(msgRecorder, nameInner, "name");
                     checkAttributeString(msgRecorder, column.getName(), "column");
 
@@ -1074,10 +1075,10 @@ public class ExplicitRules {
         protected final int id;
         protected final boolean ignoreCase;
         protected final ExplicitRules.Group aggGroup;
-        protected org.eclipse.daanse.rolap.mapping.model.Column factCountColumn;
-        protected Map<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column> measuresFactCount = new HashMap<>();
-        protected List<org.eclipse.daanse.rolap.mapping.model.Column> ignoreColumns;
-        private Map<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column> foreignKeyMap;
+        protected org.eclipse.daanse.cwm.model.cwm.resource.relational.Column factCountColumn;
+        protected Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> measuresFactCount = new HashMap<>();
+        protected List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> ignoreColumns;
+        private Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> foreignKeyMap;
         private List<Level> levels;
         private List<Measure> measures;
         protected int approxRowCount = Integer.MIN_VALUE;
@@ -1129,25 +1130,25 @@ public class ExplicitRules {
         /**
          * Get the name of the fact count column.
          */
-        protected org.eclipse.daanse.rolap.mapping.model.Column getFactCountColumn() {
+        protected org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getFactCountColumn() {
             return factCountColumn;
         }
 
         /**
          * Set the name of the fact count column.
          */
-        protected void setFactCountColumn(final org.eclipse.daanse.rolap.mapping.model.Column factCountColumn) {
+        protected void setFactCountColumn(final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column factCountColumn) {
             this.factCountColumn = factCountColumn;
         }
 
-        public Map<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column> getMeasuresFactCount() {
+        public Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> getMeasuresFactCount() {
             return measuresFactCount;
         }
 
         /**
          * Get an Iterator over all ignore column name entries.
          */
-        protected Iterator<org.eclipse.daanse.rolap.mapping.model.Column> getIgnoreColumns() {
+        protected Iterator<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> getIgnoreColumns() {
             return ignoreColumns.iterator();
         }
 
@@ -1172,11 +1173,11 @@ public class ExplicitRules {
             return new Recognizer.Matcher() {
                 @Override
 				public boolean matches(final String name) {
-                    for (Iterator<org.eclipse.daanse.rolap.mapping.model.Column> it =
+                    for (Iterator<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> it =
                             ExplicitRules.TableDef.this.getIgnoreColumns();
                         it.hasNext();)
                     {
-                    	org.eclipse.daanse.rolap.mapping.model.Column ignoreName = it.next();
+                    	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column ignoreName = it.next();
                         if (isIgnoreCase()) {
                             if (ignoreName.getName().equalsIgnoreCase(name)) {
                                 return true;
@@ -1200,7 +1201,7 @@ public class ExplicitRules {
                 @Override
 				public boolean matches(String name) {
                     // Match is case insensitive
-                    final org.eclipse.daanse.rolap.mapping.model.Column factCountColumnInner = TableDef.this.factCountColumn;
+                    final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column factCountColumnInner = TableDef.this.factCountColumn;
                     return factCountColumnInner != null && factCountColumnInner.getName() != null
                         && factCountColumnInner.getName().equalsIgnoreCase(name);
                 }
@@ -1211,9 +1212,9 @@ public class ExplicitRules {
             return new Recognizer.Matcher() {
                 @Override
                 public boolean matches(String name) {
-                    HashSet<org.eclipse.daanse.rolap.mapping.model.Column> measuresFactCountSet =
+                    HashSet<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> measuresFactCountSet =
                             new HashSet<>(measuresFactCount.values());
-                    return measuresFactCountSet.stream().filter(Objects::nonNull).map(org.eclipse.daanse.rolap.mapping.model.Column::getName).anyMatch(n -> name.equals(n));
+                    return measuresFactCountSet.stream().filter(Objects::nonNull).map(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column::getName).anyMatch(n -> name.equals(n));
                 }
             };
         }
@@ -1246,7 +1247,7 @@ public class ExplicitRules {
         /**
          * Adds the name of an aggregate table column that is to be ignored.
          */
-        protected void addIgnoreColumn(final org.eclipse.daanse.rolap.mapping.model.Column ignoreName) {
+        protected void addIgnoreColumn(final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column ignoreName) {
             if (this.ignoreColumns == EMPTY_LIST) {
                 this.ignoreColumns = new ArrayList<>();
             }
@@ -1257,7 +1258,7 @@ public class ExplicitRules {
          * Add foreign key mapping entry (maps from fact table foreign key
          * column name to aggregate table foreign key column name).
          */
-        protected void addFK(final org.eclipse.daanse.rolap.mapping.model.AggregationForeignKey fk) {
+        protected void addFK(final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationForeignKey fk) {
             if (this.foreignKeyMap == EMPTY_MAP) {
                 this.foreignKeyMap = new HashMap<>();
             }
@@ -1270,8 +1271,8 @@ public class ExplicitRules {
          * Get the name of the aggregate table's foreign key column that matches
          * the base fact table's foreign key column or return null.
          */
-        protected org.eclipse.daanse.rolap.mapping.model.Column getAggregateFK(final String baseFK) {
-        	Optional<Map.Entry<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column>> op = this.foreignKeyMap.entrySet().stream().filter(e -> baseFK.equals(e.getKey().getName())).findFirst();
+        protected org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getAggregateFK(final String baseFK) {
+        	Optional<Map.Entry<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column>> op = this.foreignKeyMap.entrySet().stream().filter(e -> baseFK.equals(e.getKey().getName())).findFirst();
             if (op.isPresent()) {
             	return op.get().getValue();
             }
@@ -1394,9 +1395,9 @@ public class ExplicitRules {
                 RolapStar star = getStar();
                 RolapStar.Table factTable = star.getFactTable();
                 String tableName = factTable.getAlias();
-                for (Map.Entry<org.eclipse.daanse.rolap.mapping.model.Column, org.eclipse.daanse.rolap.mapping.model.Column> e : foreignKeyMap.entrySet()) {
-                	org.eclipse.daanse.rolap.mapping.model.Column baseFKName = e.getKey();
-                	org.eclipse.daanse.rolap.mapping.model.Column aggFKName = e.getValue();
+                for (Map.Entry<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> e : foreignKeyMap.entrySet()) {
+                	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column baseFKName = e.getKey();
+                	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column aggFKName = e.getValue();
 
                     if (namesToObjects.containsKey(baseFKName.getName())) {
                         msgRecorder.reportError(
@@ -1476,7 +1477,7 @@ public class ExplicitRules {
          * Makes a NameTableDef from the catalog schema.
          */
         static ExplicitRules.NameTableDef make(
-            final org.eclipse.daanse.rolap.mapping.model.AggregationName aggName,
+            final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName aggName,
             final ExplicitRules.Group group)
         {
             ExplicitRules.NameTableDef name =
@@ -1491,10 +1492,10 @@ public class ExplicitRules {
             return name;
         }
 
-        private final org.eclipse.daanse.rolap.mapping.model.Table name;
+        private final org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet name;
 
         public NameTableDef(
-            final org.eclipse.daanse.rolap.mapping.model.Table name,
+            final org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet name,
             final String approxRowCount,
             final boolean ignoreCase,
             final ExplicitRules.Group group)
@@ -1565,7 +1566,7 @@ public class ExplicitRules {
          * Make a PatternTableDef from the catalog schema.
          */
         static ExplicitRules.PatternTableDef make(
-            final org.eclipse.daanse.rolap.mapping.model.AggregationPattern aggPattern,
+            final org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationPattern aggPattern,
             final ExplicitRules.Group group)
         {
             ExplicitRules.PatternTableDef pattern =
@@ -1574,9 +1575,9 @@ public class ExplicitRules {
                     aggPattern.isIgnorecase(),
                     group);
 
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationExclude> excludes = aggPattern.getExcludes();
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude> excludes = aggPattern.getExcludes();
             if (excludes != null) {
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationExclude exclude1 : excludes) {
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude exclude1 : excludes) {
                     Exclude exclude = ExplicitRules.make(exclude1);
                     pattern.add(exclude);
                 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/JdbcSchema.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/JdbcSchema.java
@@ -27,7 +27,7 @@ package org.eclipse.daanse.rolap.common.aggmatcher;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.sql.JDBCType;
+import org.eclipse.daanse.cwm.util.resource.relational.SqlSimpleTypes;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.text.MessageFormat;
@@ -50,7 +50,7 @@ import org.eclipse.daanse.olap.api.sql.SqlExpression;
 import org.eclipse.daanse.rolap.common.star.RolapSqlExpression;
 import org.eclipse.daanse.rolap.common.star.RolapStar;
 import org.eclipse.daanse.rolap.element.RolapLevel;
-import org.eclipse.daanse.rolap.mapping.model.ColumnType;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -223,7 +223,7 @@ public class JdbcSchema {
                 public RolapStar.Measure rMeasure;
 
                 // hierarchy stuff
-                public org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation;
+                public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation;
                 public SqlExpression joinExp;
                 public String levelColumnName;
 
@@ -724,31 +724,36 @@ public class JdbcSchema {
          */
         private final String tableType;
 
-        private final org.eclipse.daanse.rolap.mapping.model.Table modelTable; 
+        private final org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet modelTable; 
         
         // mondriandef stuff
-        public org.eclipse.daanse.rolap.mapping.model.TableQuery table;
+        public org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table;
 
-        private Table(final String name, String tableType, List<? extends org.eclipse.daanse.rolap.mapping.model.Column> list, org.eclipse.daanse.rolap.mapping.model.Table modelTable) {
+        private Table(final String name, String tableType, List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> list, org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet modelTable) {
             this.name = name;
             this.tableUsageType = TableUsageType.UNKNOWN;
             this.tableType = tableType;
             this.modelTable = modelTable;
 
-			for (org.eclipse.daanse.rolap.mapping.model.Column rdbColumn : list) {
+			for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Column rdbColumn : list) {
 
 				String nameInner = rdbColumn.getName();
-				int type = rdbColumn.getType() != null ? JDBCType.valueOf(rdbColumn.getType().name()).getVendorTypeNumber() : 0;
-				ColumnType typeName = rdbColumn.getType();
-				Integer columnSize = rdbColumn.getColumnSize() == null ? 0 : rdbColumn.getColumnSize();
-				Integer decimalDigits = rdbColumn.getDecimalDigits() == null ? 0 : rdbColumn.getDecimalDigits();
-				int numPrecRadix = rdbColumn.getNumPrecRadix() == null ? 0 : rdbColumn.getNumPrecRadix();
-				int charOctetLength = rdbColumn.getCharOctetLength() == null ? 0 : rdbColumn.getCharOctetLength();
-				boolean isNullable = Boolean.TRUE == rdbColumn.getNullable();
+				org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType rdbType =
+					rdbColumn.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType st ? st : null;
+				String typeName = rdbType != null ? rdbType.getName() : null;
+				// Read the JDBC type code straight from the SQLSimpleType.typeNumber
+				// field; avoids JDBCType.valueOf(name) failing on SQL-99 spec names
+				// such as "CHARACTER VARYING" or "DOUBLE PRECISION".
+				int type = rdbType != null ? SqlSimpleTypes.jdbcType(rdbType) : 0;
+				Integer columnSize = rdbType == null ? 0 : (int) rdbType.getCharacterMaximumLength();
+				Integer decimalDigits = rdbType == null ? 0 : (int) rdbType.getNumericScale();
+				int numPrecRadix = rdbType == null ? 0 : (int) rdbType.getNumericPrecisionRadix();
+				int charOctetLength = rdbType == null ? 0 : (int) rdbType.getCharacterOctetLength();
+				boolean isNullable = rdbColumn.getIsNullable() == null || rdbColumn.getIsNullable().getValue() == 1;
 
 				Column column = new Column(nameInner);
 				column.setType(type);
-				column.setTypeName(typeName != null ? typeName.name() : null);
+				column.setTypeName(typeName);
 				column.setColumnSize(columnSize);
 				column.setDecimalDigits(decimalDigits);
 				column.setNumPrecRadix(numPrecRadix);
@@ -756,7 +761,7 @@ public class JdbcSchema {
 				column.setIsNullable(isNullable);
 
 				getColumnMap().put(column.getName(), column);
-				totalColumnSize += column.getColumnSize();
+				totalColumnSize += (columnSize != null ? columnSize : 0);
 			}
         }
 
@@ -895,7 +900,7 @@ public class JdbcSchema {
             return tableType;
         }
 
-        public org.eclipse.daanse.rolap.mapping.model.Table getModelTable() {
+        public org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet getModelTable() {
             return modelTable;
         }
 
@@ -945,7 +950,7 @@ public class JdbcSchema {
         }
     }
 
-    private org.eclipse.daanse.rolap.mapping.model.DatabaseSchema databaseSchema;
+    private org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema databaseSchema;
 
     /**
      * Tables by name. We use a sorted map so {@link #getTables()}'s output
@@ -954,7 +959,7 @@ public class JdbcSchema {
     private final SortedMap<String, Table> tables =
         new TreeMap<>();
 
-	public JdbcSchema(final org.eclipse.daanse.rolap.mapping.model.DatabaseSchema databaseSchema) {
+	public JdbcSchema(final org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema databaseSchema) {
 		this.databaseSchema = databaseSchema;
 		loadTables();
 	}
@@ -1013,10 +1018,16 @@ public class JdbcSchema {
      */
 	protected void loadTables() {
 
-		for (org.eclipse.daanse.rolap.mapping.model.Table rdbTable : databaseSchema.getTables()) {
-			if (rdbTable instanceof org.eclipse.daanse.rolap.mapping.model.PhysicalTable || rdbTable instanceof org.eclipse.daanse.rolap.mapping.model.ViewTable || rdbTable instanceof org.eclipse.daanse.rolap.mapping.model.SystemTable) {
+		for (org.eclipse.daanse.cwm.model.cwm.objectmodel.core.ModelElement _me : databaseSchema.getOwnedElement()) {
+			if (!(_me instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet rdbTable)) continue;
+			if (rdbTable instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.Table || rdbTable instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.View || rdbTable instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) {
 
-			Table table = new Table(rdbTable.getName(), rdbTable.getClass().getSimpleName(),rdbTable.getColumns(), rdbTable);
+			java.util.List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> _tblCols =
+				rdbTable.getFeature().stream()
+					.filter(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column.class::isInstance)
+					.map(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column.class::cast)
+					.toList();
+			Table table = new Table(rdbTable.getName(), rdbTable.getClass().getSimpleName(), _tblCols, rdbTable);
 				getLogger().debug("Adding table {}", rdbTable.getName());
 				tables.put(table.getName(), table);
 			}

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/Recognizer.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/Recognizer.java
@@ -563,7 +563,7 @@ public abstract class Recognizer {
                         // Search through the notSeenForeignKeys list
                         // making sure that this HierarchyUsage's
                         // foreign key is not in the list.
-                    	org.eclipse.daanse.rolap.mapping.model.Column foreignKey = hierarchyUsage.getForeignKey();
+                    	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column foreignKey = hierarchyUsage.getForeignKey();
                         boolean b = foreignKey == null
                             || inNotSeenForeignKeys(
                             foreignKey,
@@ -585,7 +585,7 @@ public abstract class Recognizer {
      * foreign keys.
      */
     boolean inNotSeenForeignKeys(
-        org.eclipse.daanse.rolap.mapping.model.Column foreignKey,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column foreignKey,
         List<JdbcSchema.Table.Column.Usage> notSeenForeignKeys
     ) {
         for (JdbcSchema.Table.Column.Usage usage : notSeenForeignKeys) {
@@ -672,7 +672,7 @@ public abstract class Recognizer {
                      uit.hasNext(); ) {
                     JdbcSchema.Table.Column.Usage aggUsage = uit.next();
 
-                    org.eclipse.daanse.rolap.mapping.model.RelationalQuery rel = hierarchyUsage.getJoinTable();
+                    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel = hierarchyUsage.getJoinTable();
 
                     if (!aggUsageMatchesHierarchyUsage(aggUsage,
                         hierarchyUsage, levelColumnName)) {
@@ -807,7 +807,7 @@ public abstract class Recognizer {
         HierarchyUsage hierarchyUsage,
         String levelColumnName
     ) {
-    	org.eclipse.daanse.rolap.mapping.model.RelationalQuery rel = hierarchyUsage.getJoinTable();
+    	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel = hierarchyUsage.getJoinTable();
 
         JdbcSchema.Table.Column aggColumn = aggUsage.getColumn();
         String aggColumnName = aggColumn.column.getName();

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggregator/AggregationFactoryImpl.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggregator/AggregationFactoryImpl.java
@@ -46,52 +46,52 @@ public class AggregationFactoryImpl implements AggregationFactory{
     @Override
     public Aggregator getAggregator(Object measure) {
         return switch (measure) {
-            case org.eclipse.daanse.rolap.mapping.model.SumMeasure i -> SumAggregator.INSTANCE;
-            case org.eclipse.daanse.rolap.mapping.model.MaxMeasure i -> MaxAggregator.INSTANCE;
-            case org.eclipse.daanse.rolap.mapping.model.MinMeasure i -> MinAggregator.INSTANCE;
-            case org.eclipse.daanse.rolap.mapping.model.AvgMeasure i  -> AvgAggregator.INSTANCE;
-            case org.eclipse.daanse.rolap.mapping.model.CountMeasure i -> getCountAggregator(i);
-            case org.eclipse.daanse.rolap.mapping.model.TextAggMeasure i -> getListAggAggregator(i);
-            case org.eclipse.daanse.rolap.mapping.model.NoneMeasure i -> NoneAggregator.INSTANCE;
-            case org.eclipse.daanse.rolap.mapping.model.BitAggMeasure i -> getBitAggAggregator(i);
-            case org.eclipse.daanse.rolap.mapping.model.PercentileMeasure i -> getPercentileAggregator(i);
-            case org.eclipse.daanse.rolap.mapping.model.CustomMeasure i -> findCustomAggregator(i);
-            case org.eclipse.daanse.rolap.mapping.model.NthAggMeasure i -> getNthValueAggregator(i);
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.SumMeasure i -> SumAggregator.INSTANCE;
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MaxMeasure i -> MaxAggregator.INSTANCE;
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MinMeasure i -> MinAggregator.INSTANCE;
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.AvgMeasure i  -> AvgAggregator.INSTANCE;
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CountMeasure i -> getCountAggregator(i);
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.TextAggMeasure i -> getListAggAggregator(i);
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.NoneMeasure i -> NoneAggregator.INSTANCE;
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggMeasure i -> getBitAggAggregator(i);
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.PercentileMeasure i -> getPercentileAggregator(i);
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CustomMeasure i -> findCustomAggregator(i);
+            case org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.NthAggMeasure i -> getNthValueAggregator(i);
             default -> throw new RuntimeException("Incorect aggregation type");
         };
     }
 
-    private Aggregator getCountAggregator(org.eclipse.daanse.rolap.mapping.model.CountMeasure i) {
+    private Aggregator getCountAggregator(org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CountMeasure i) {
         return (i.isDistinct() ? DistinctCountAggregator.INSTANCE : CountAggregator.INSTANCE);
     }
 
-    private Aggregator getListAggAggregator(org.eclipse.daanse.rolap.mapping.model.TextAggMeasure i) {
+    private Aggregator getListAggAggregator(org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.TextAggMeasure i) {
         return new ListAggAggregator(i.isDistinct(), i.getSeparator(), getOrderedColumns(i.getOrderByColumns()), i.getCoalesce(), i.getOnOverflowTruncate(), dialect);
     }
 
-    private Aggregator getNthValueAggregator(org.eclipse.daanse.rolap.mapping.model.NthAggMeasure i) {
+    private Aggregator getNthValueAggregator(org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.NthAggMeasure i) {
         return new NthValueAggregator(i.isIgnoreNulls(), i.getN(),
                 getOrderedColumns(i.getOrderByColumns()), dialect);
     }
 
-    private Aggregator getPercentileAggregator(org.eclipse.daanse.rolap.mapping.model.PercentileMeasure measure) {
-    	org.eclipse.daanse.rolap.mapping.model.OrderedColumn oc = measure.getColumn();
+    private Aggregator getPercentileAggregator(org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.PercentileMeasure measure) {
+    	org.eclipse.daanse.rolap.mapping.model.database.relational.OrderedColumn oc = measure.getColumn();
             return new PercentileAggregator(measure.getPercentType(), measure.getPercentile(),
-                    new RolapColumn(oc.getColumn().getTable().getName(), oc.getColumn().getName(), SortingDirection.valueOf(oc.getDirection().name())), dialect);
+                    new RolapColumn(((org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet) oc.getColumn().getOwner()).getName(), oc.getColumn().getName(), SortingDirection.valueOf(oc.getDirection().name())), dialect);
     }
 
-    private Aggregator getBitAggAggregator(org.eclipse.daanse.rolap.mapping.model.BitAggMeasure measure) {
+    private Aggregator getBitAggAggregator(org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BitAggMeasure measure) {
         return new BitAggAggregator(measure.isNot(), measure.getAggType(), dialect);
     }
 
-    private List<RolapColumn> getOrderedColumns(List<? extends org.eclipse.daanse.rolap.mapping.model.OrderedColumn> orderByColumns) {
+    private List<RolapColumn> getOrderedColumns(List<? extends org.eclipse.daanse.rolap.mapping.model.database.relational.OrderedColumn> orderByColumns) {
         if (orderByColumns != null) {
-            return orderByColumns.stream().map(oc -> new RolapColumn(oc.getColumn().getTable().getName(), oc.getColumn().getName(), SortingDirection.valueOf(oc.getDirection().name()))).toList();
+            return orderByColumns.stream().map(oc -> new RolapColumn(((org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet) oc.getColumn().getOwner()).getName(), oc.getColumn().getName(), SortingDirection.valueOf(oc.getDirection().name()))).toList();
         }
         return List.of();
     }
 
-    private Aggregator findCustomAggregator(org.eclipse.daanse.rolap.mapping.model.CustomMeasure i) {
+    private Aggregator findCustomAggregator(org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CustomMeasure i) {
         Optional<CustomAggregatorFactory> oAggregator = customAggregators.stream().filter(ca -> i.getName().equals(ca.getName())).findAny();
         if (oAggregator.isPresent()) {
             List<Object> l = (i.getColumns() == null) ? List.of() : i.getColumns().stream().map(Object.class::cast).toList();

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/catalog/RolapCatalogCache.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/catalog/RolapCatalogCache.java
@@ -141,7 +141,7 @@ public class RolapCatalogCache implements CatalogCache {
      * @param connectionProps connection properties containing cache and timeout settings
      * @return the cached or newly created catalog
      */
-    public RolapCatalog getOrCreateCatalog(org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping, final ConnectionProps connectionProps) {
+    public RolapCatalog getOrCreateCatalog(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping, final ConnectionProps connectionProps) {
 
         final boolean useCatalogCache = connectionProps.useCatalogCache();
         final RolapCatalogContentKey catalogContentKey = RolapCatalogContentKey.create(catalogMapping);

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/catalog/RolapCatalogContentKey.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/catalog/RolapCatalogContentKey.java
@@ -14,7 +14,7 @@
 package org.eclipse.daanse.rolap.common.catalog;
 
 public record RolapCatalogContentKey(String catalogName, int catalogMappingHash) {
-	public static RolapCatalogContentKey create(org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping) {
+	public static RolapCatalogContentKey create(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping) {
 
 		int hash = System.identityHashCode(catalogMapping);
 		return new RolapCatalogContentKey(catalogMapping.getName(), hash);

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/catalog/RolapCubeUsages.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/catalog/RolapCubeUsages.java
@@ -38,9 +38,9 @@ import java.util.List;
  * @since Nov 22 2007
  */
 public class RolapCubeUsages {
-    private List<? extends org.eclipse.daanse.rolap.mapping.model.CubeConnector> cubeUsages;
+    private List<? extends org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeConnector> cubeUsages;
 
-    public RolapCubeUsages(List<? extends org.eclipse.daanse.rolap.mapping.model.CubeConnector> cubeUsage) {
+    public RolapCubeUsages(List<? extends org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeConnector> cubeUsage) {
         this.cubeUsages = cubeUsage;
     }
 
@@ -48,7 +48,7 @@ public class RolapCubeUsages {
         if (cubeUsages == null) {
             return false;
         }
-        for (org.eclipse.daanse.rolap.mapping.model.CubeConnector usage : cubeUsages) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeConnector usage : cubeUsages) {
             if (usage.getCube().getName().equals(baseCubeName)
                 && Boolean.TRUE.equals(usage.isIgnoreUnrelatedDimensions()))
             {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/connection/AbstractRolapConnection.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/connection/AbstractRolapConnection.java
@@ -145,7 +145,7 @@ public abstract class AbstractRolapConnection extends ConnectionBase {
 
             catalog = ExecutionContext.where(execution.asContext(), () -> {
                 // TODO: switch from schemareader to catalogreader;
-                org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping = context.getCatalogMapping();
+                org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping = context.getCatalogMapping();
                 return ((RolapCatalogCache) context.getCatalogCache()).getOrCreateCatalog(catalogMapping, connectionProps);
             });
             bootstrapStatement.close();

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/sql/SqlQuery.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/sql/SqlQuery.java
@@ -145,14 +145,14 @@ public class SqlQuery {
     /** Scratch buffer. Clear it before use. */
     private final StringBuilder buf;
 
-    private final Set<org.eclipse.daanse.rolap.mapping.model.RelationalQuery> relations =
+    private final Set<org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource> relations =
         new HashSet<>();
 
-    private final Map<org.eclipse.daanse.rolap.mapping.model.RelationalQuery, org.eclipse.daanse.rolap.mapping.model.Query>
+    private final Map<org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource, org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource>
         mapRelationToRoot =
         new HashMap<>();
 
-    private final Map<org.eclipse.daanse.rolap.mapping.model.Query, List<RelInfo>>
+    private final Map<org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource, List<RelInfo>>
         mapRootToRelations =
         new HashMap<>();
 
@@ -369,13 +369,13 @@ public class SqlQuery {
      * @return true, if relation *was* added to query
      */
     public boolean addFrom(
-        final org.eclipse.daanse.rolap.mapping.model.Query relation,
+        final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         final String alias,
         final boolean failIfExists)
     {
         registerRootRelation(relation);
 
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation1) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation1) {
             if (relations.add(relation1)
                 && !SystemWideProperties.instance()
                 .FilterChildlessSnowflakeMembers)
@@ -386,11 +386,11 @@ public class SqlQuery {
                 // (If FilterChildlessSnowflakeMembers were false,
                 // this would be unnecessary. Adding a relation automatically
                 // adds all relations between it and the fact table.)
-                org.eclipse.daanse.rolap.mapping.model.Query root =
+                org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource root =
                     mapRelationToRoot.get(relation1);
-                List<org.eclipse.daanse.rolap.mapping.model.RelationalQuery> relationsCopy =
+                List<org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource> relationsCopy =
                     new ArrayList<>(relations);
-                for (org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation2 : relationsCopy) {
+                for (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation2 : relationsCopy) {
                     if (relation2 != relation1
                         && mapRelationToRoot.get(relation2) == root)
                     {
@@ -401,29 +401,29 @@ public class SqlQuery {
         }
 
         return switch (relation) {
-            case org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view -> {
+            case org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view -> {
                 final String viewAlias = alias != null ? alias : RelationUtil.getAlias(view);
                 final String sqlString = getCodeSet(view).chooseQuery(dialect);
                 yield addFromQuery(sqlString, viewAlias, false);
             }
-            case org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTable -> {
-                final org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation1 =
+            case org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTable -> {
+                final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation1 =
                     RolapUtil.convertInlineTableToRelation(inlineTable, dialect);
                 yield addFrom(relation1, alias, failIfExists);
             }
-            case org.eclipse.daanse.rolap.mapping.model.TableQuery table -> {
+            case org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table -> {
                 final String tableAlias = alias != null ? alias : RelationUtil.getAlias(table);
                 yield addFromTable(
-                    getSchemaName(table.getTable().getSchema()),
+                    getSchemaName((org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema) table.getTable().getNamespace()),
                     table.getTable().getName(),
                     tableAlias,
                     Optional.ofNullable(table.getSqlWhereExpression())
-                        .map(org.eclipse.daanse.rolap.mapping.model.SqlStatement::getSql)
+                        .map(org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement::getSql)
                         .orElse(null),
                     getHintMap(table),
                     failIfExists);
             }
-            case org.eclipse.daanse.rolap.mapping.model.JoinQuery join -> addJoin(
+            case org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join -> addJoin(
                 left(join),
                 getLeftAlias(join),
                 join.getLeft().getKey(),
@@ -435,17 +435,17 @@ public class SqlQuery {
         };
     }
 
-    private String getSchemaName(org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema) {
+    private String getSchemaName(org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema) {
         return schema != null ? schema.getName() : null;
     }
 
 	private boolean addJoin(
-	    org.eclipse.daanse.rolap.mapping.model.Query left,
+	    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left,
         String leftAlias,
-        org.eclipse.daanse.rolap.mapping.model.Column leftKey,
-        org.eclipse.daanse.rolap.mapping.model.Query right,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column leftKey,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right,
         String rightAlias,
-        org.eclipse.daanse.rolap.mapping.model.Column rightKey,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column rightKey,
         boolean failIfExists)
     {
         boolean addLeft = addFrom(left, leftAlias, failIfExists);
@@ -471,9 +471,9 @@ public class SqlQuery {
     }
 
     private void addJoinBetween(
-        org.eclipse.daanse.rolap.mapping.model.Query root,
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation1,
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation2)
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource root,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation1,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation2)
     {
         List<RelInfo> relations = mapRootToRelations.get(root);
         int index1 = find(relations, relation1);
@@ -499,7 +499,7 @@ public class SqlQuery {
         }
     }
 
-    private int find(List<RelInfo> relations, org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
+    private int find(List<RelInfo> relations, org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
         return IntStream.range(0, relations.size())
             .filter(i -> Utils.equalsQuery(relations.get(i).relation(), relation))
             .findFirst()
@@ -821,7 +821,7 @@ public class SqlQuery {
         return Pair.of(toString(), types);
     }
 
-    public void registerRootRelation(org.eclipse.daanse.rolap.mapping.model.Query root) {
+    public void registerRootRelation(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource root) {
         // REVIEW: In this method, we are building data structures about the
         // structure of a star schema. These should be built into the schema,
         // not constructed afresh for each SqlQuery. In mondrian-4.0,
@@ -843,13 +843,13 @@ public class SqlQuery {
 
     private void flatten(
         List<RelInfo> relations,
-        org.eclipse.daanse.rolap.mapping.model.Query root,
-        org.eclipse.daanse.rolap.mapping.model.Column leftKey,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource root,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column leftKey,
         String leftAlias,
-        org.eclipse.daanse.rolap.mapping.model.Column rightKey,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column rightKey,
         String rightAlias)
     {
-        if (root instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+        if (root instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
             flatten(
                 relations, left(join), join.getLeft().getKey(), getLeftAlias(join),
                 join.getRight().getKey(), getRightAlias(join));
@@ -859,7 +859,7 @@ public class SqlQuery {
         } else {
             relations.add(
                 new RelInfo(
-                    (org.eclipse.daanse.rolap.mapping.model.RelationalQuery) root,
+                    (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) root,
                     leftKey,
                     leftAlias,
                     rightKey,
@@ -1121,10 +1121,10 @@ public class SqlQuery {
      * @param rightAlias the alias for the right table
      */
     private record RelInfo(
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
-        org.eclipse.daanse.rolap.mapping.model.Column leftKey,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column leftKey,
         String leftAlias,
-        org.eclipse.daanse.rolap.mapping.model.Column rightKey,
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.Column rightKey,
         String rightAlias) {
     }
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/star/HierarchyUsage.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/star/HierarchyUsage.java
@@ -92,7 +92,7 @@ public class HierarchyUsage {
      * identifies the usage, and determines which join conditions need to be
      * used.
      */
-    protected final org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact;
+    protected final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact;
 
     /**
      * This matches the hierarchy - may not be unique.
@@ -122,7 +122,7 @@ public class HierarchyUsage {
      * The foreign key by which this {@link Hierarchy} is joined to
      * the {@link #fact} table.
      */
-    private final org.eclipse.daanse.rolap.mapping.model.Column foreignKey;
+    private final org.eclipse.daanse.cwm.model.cwm.resource.relational.Column foreignKey;
 
     /**
      * not NULL for DimensionUsage
@@ -143,7 +143,7 @@ public class HierarchyUsage {
      * Dimension table which contains the primary key for the hierarchy.
      * (Usually the table of the lowest level of the hierarchy.)
      */
-    private org.eclipse.daanse.rolap.mapping.model.RelationalQuery joinTable;
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource joinTable;
 
     /**
      * The expression (usually a {@link mondrian.olap.MappingColumn}) by
@@ -163,7 +163,7 @@ public class HierarchyUsage {
     public HierarchyUsage(
         RolapCube cube,
         RolapHierarchy hierarchy,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim)
     {
         assert cubeDim != null : "precondition: cubeDim != null";
 
@@ -174,7 +174,7 @@ public class HierarchyUsage {
         // foreignKey
         this.name = cubeDim.getOverrideDimensionName();
         this.foreignKey = cubeDim.getForeignKey();
-        org.eclipse.daanse.rolap.mapping.model.Dimension du = cubeDim.getDimension();
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension du = cubeDim.getDimension();
 
         this.kind = Kind.SHARED;
 
@@ -325,7 +325,7 @@ public class HierarchyUsage {
     public String getName() {
         return this.name;
     }
-    public org.eclipse.daanse.rolap.mapping.model.Column getForeignKey() {
+    public org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getForeignKey() {
         return this.foreignKey;
     }
     public String getSource() {
@@ -338,7 +338,7 @@ public class HierarchyUsage {
         return this.usagePrefix;
     }
 
-    public org.eclipse.daanse.rolap.mapping.model.RelationalQuery getJoinTable() {
+    public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getJoinTable() {
         return this.joinTable;
     }
 
@@ -408,7 +408,7 @@ public class HierarchyUsage {
     void init(
         RolapCube cube,
         RolapHierarchy hierarchy,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim)
     {
         // Three ways that a hierarchy can be joined to the fact table.
         if (cubeDim != null && cubeDim.getLevel() != null) {
@@ -435,10 +435,15 @@ public class HierarchyUsage {
             // 2. Specify a "primaryKey" attribute of in <Hierarchy>. You must
             //    also specify the "primaryKeyTable" attribute if the hierarchy
             //    is a join (hence has more than one table).
+            // PK owner may be a NamedColumnSet (Table/View) or a Daanse
+            // InlineTable (extends ColumnSet directly). Only pass if it is a
+            // NamedColumnSet — findJoinTable expects a named-DB-schema element.
             this.joinTable =
                 findJoinTable(
                     hierarchy,
-                    hierarchy.getHierarchyMapping().getPrimaryKey().getTable());
+                    hierarchy.getHierarchyMapping().getPrimaryKey().getOwner()
+                        instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet named
+                        ? named : null);
             this.joinExp =
                 new org.eclipse.daanse.rolap.element.RolapColumn(
                     getAlias(this.joinTable),
@@ -486,11 +491,11 @@ public class HierarchyUsage {
      *   has only one table
      * @return A table, never null
      */
-    private org.eclipse.daanse.rolap.mapping.model.RelationalQuery findJoinTable(
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource findJoinTable(
         RolapHierarchy hierarchy,
-        org.eclipse.daanse.rolap.mapping.model.Table tab)
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet tab)
     {
-        final org.eclipse.daanse.rolap.mapping.model.RelationalQuery table;
+        final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table;
         if (tab == null || tab.getName() == null) {
             table = hierarchy.getUniqueTable();
             if (table == null) {
@@ -510,11 +515,11 @@ public class HierarchyUsage {
         return table;
     }
 
-    private org.eclipse.daanse.rolap.mapping.model.RelationalQuery findJoinTable(
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource findJoinTable(
             RolapHierarchy hierarchy,
             String tableName)
         {
-            final org.eclipse.daanse.rolap.mapping.model.RelationalQuery table;
+            final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table;
             if (tableName == null) {
                 table = hierarchy.getUniqueTable();
                 if (table == null) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/star/RelNode.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/star/RelNode.java
@@ -26,11 +26,11 @@ public class RelNode {
      * @param map Names of tables and RelNode pairs
      */
     public static RelNode lookup(
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery table,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table,
         Map<String, RelNode> map)
     {
         RelNode relNode;
-        if (table instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery t) {
+        if (table instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource t) {
             relNode = map.get(t.getTable().getName());
             if (relNode != null) {
                 return relNode;
@@ -41,14 +41,14 @@ public class RelNode {
 
     private int depth;
     private String alias;
-    private org.eclipse.daanse.rolap.mapping.model.RelationalQuery table;
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table;
 
     public RelNode(String alias, int depth) {
         this.alias = alias;
         this.depth = depth;
     }
 
-    public void setTable(org.eclipse.daanse.rolap.mapping.model.RelationalQuery table) {
+    public void setTable(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table) {
         this.table = table;
     }
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapSqlExpression.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapSqlExpression.java
@@ -24,11 +24,11 @@ public class RolapSqlExpression implements org.eclipse.daanse.olap.api.sql.SqlEx
     
     public RolapSqlExpression() {
     }
-    public RolapSqlExpression(org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn scm) {
+    public RolapSqlExpression(org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn scm) {
         this(scm, SortingDirection.ASC);
     }
     
-    public RolapSqlExpression(org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn scm, SortingDirection sortingDirection) {
+    public RolapSqlExpression(org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn scm, SortingDirection sortingDirection) {
         if (scm.getSqls() != null) {
             this.sqls = scm.getSqls().stream().map(ex -> (org.eclipse.daanse.olap.api.SqlStatement)RolapSqlStatement.builder().withDialects(ex.getDialects()).withSql(ex.getSql()).build()).toList();
             this.sortingDirection = sortingDirection;

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapStar.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapStar.java
@@ -94,8 +94,8 @@ import org.eclipse.daanse.rolap.element.RolapCubeLevel;
 import org.eclipse.daanse.rolap.element.RolapLevel;
 import org.eclipse.daanse.rolap.element.RolapProperty;
 import org.eclipse.daanse.rolap.element.RolapStoredMeasure;
-import org.eclipse.daanse.rolap.mapping.model.JoinQuery;
-import org.eclipse.daanse.rolap.mapping.model.Query;
+import org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource;
+import org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,6 +103,8 @@ import org.slf4j.LoggerFactory;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 /**
  * A RolapStar is a star schema. It is the means to read cell
  * values.
@@ -165,7 +167,7 @@ public class RolapStar {
     protected RolapStar(
         final RolapCatalog catalog,
         final Context context,
-        final org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact)
+        final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact)
     {
         this.cacheAggregations = true;
         this.catalog = catalog;
@@ -299,13 +301,13 @@ public class RolapStar {
 
     private static class StarNetworkNode {
         private StarNetworkNode parent;
-        private org.eclipse.daanse.rolap.mapping.model.RelationalQuery origRel;
+        private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource origRel;
         private String foreignKey;
         private String joinKey;
 
         private StarNetworkNode(
             StarNetworkNode parent,
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery origRel,
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource origRel,
             String foreignKey,
             String joinKey)
         {
@@ -317,7 +319,7 @@ public class RolapStar {
 
         private boolean isCompatible(
             StarNetworkNode compatibleParent,
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery rel,
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel,
             String compatibleForeignKey,
             String compatibleJoinKey)
         {
@@ -328,25 +330,25 @@ public class RolapStar {
         }
     }
 
-    protected org.eclipse.daanse.rolap.mapping.model.Query cloneRelation(
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery rel,
+    protected org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource cloneRelation(
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel,
         String possibleName)
     {
-        if (rel instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery tbl) {
+        if (rel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource tbl) {
         	String aliasOrName = tbl.getAlias() == null ? tbl.getTable().getName() : tbl.getAlias();
-        	org.eclipse.daanse.rolap.mapping.model.TableQuery q = RolapMappingFactory.eINSTANCE.createTableQuery();
+        	org.eclipse.daanse.rolap.mapping.model.database.source.TableSource q = SourceFactory.eINSTANCE.createTableSource();
         	q.setAlias(possibleName);
         	q.setTable(PojoUtil.getPhysicalTable(tbl.getTable()));
         	q.getOptimizationHints().addAll(tableQueryOptimizationHints(tbl.getOptimizationHints()));
         	q.setSqlWhereExpression(sql(tbl.getSqlWhereExpression(), possibleName, aliasOrName));
         	return q;
-        } else if (rel instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view) {
-        	org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery sqlSelectQuery = RolapMappingFactory.eINSTANCE.createSqlSelectQuery();
+        } else if (rel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view) {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource sqlSelectQuery = SourceFactory.eINSTANCE.createSqlSelectSource();
         	sqlSelectQuery.setAlias(possibleName);
         	sqlSelectQuery.setSql(view.getSql());
             return sqlSelectQuery;
-        } else if (rel instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTable) {
-        	org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTableQuery = RolapMappingFactory.eINSTANCE.createInlineTableQuery();
+        } else if (rel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTable) {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTableQuery = SourceFactory.eINSTANCE.createInlineTableSource();
         	inlineTableQuery.setAlias(possibleName);
         	inlineTableQuery.setTable(PojoUtil.getInlineTable(inlineTable.getTable()));
             return inlineTableQuery;
@@ -355,11 +357,11 @@ public class RolapStar {
         }
     }
 
-    protected org.eclipse.daanse.rolap.mapping.model.SqlStatement sql(org.eclipse.daanse.rolap.mapping.model.SqlStatement sql, String possibleName, String aliasOrName) {
+    protected org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sql(org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sql, String possibleName, String aliasOrName) {
         if (sql != null) {
             List<String> dialects = sql.getDialects();
             String statement = sql.getSql();
-            org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+            org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
             sqlStatement.setSql(statement != null ?
                     statement.replace(aliasOrName, possibleName) : null);
             sqlStatement.getDialects().addAll(dialects);
@@ -368,8 +370,8 @@ public class RolapStar {
         return null;
     }
 
-    protected List<? extends org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint> tableQueryOptimizationHints(
-            List<? extends org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint> optimizationHints
+    protected List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint> tableQueryOptimizationHints(
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint> optimizationHints
         ) {
             if (optimizationHints != null) {
                 return optimizationHints;
@@ -377,13 +379,13 @@ public class RolapStar {
             return List.of();
     }
 
-    protected org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint tableQueryOptimizationHint(
-    		org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint tableQueryOptimizationHint
+    protected org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint tableQueryOptimizationHint(
+    		org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint tableQueryOptimizationHint
         ) {
             if (tableQueryOptimizationHint != null) {
                 String value = tableQueryOptimizationHint.getValue();
                 String type = tableQueryOptimizationHint.getType();
-                org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint tableQueryOptimizationHintr = RolapMappingFactory.eINSTANCE.createTableQueryOptimizationHint();
+                org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint tableQueryOptimizationHintr = SourceFactory.eINSTANCE.createTableQueryOptimizationHint();
                 tableQueryOptimizationHintr.setValue(value);
                 tableQueryOptimizationHintr.setType(type);
                 return tableQueryOptimizationHintr;
@@ -404,8 +406,8 @@ public class RolapStar {
      * @param primaryKeyTable the join table of the relation
      * @return if necessary a new relation that has been re-aliased
      */
-    public org.eclipse.daanse.rolap.mapping.model.Query getUniqueRelation(
-        org.eclipse.daanse.rolap.mapping.model.Query rel,
+    public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getUniqueRelation(
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel,
         String factForeignKey,
         String primaryKey,
         String primaryKeyTable)
@@ -414,16 +416,17 @@ public class RolapStar {
             factNode, rel, factForeignKey, primaryKey, primaryKeyTable);
     }
 
-    private org.eclipse.daanse.rolap.mapping.model.Query getUniqueRelation(
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getUniqueRelation(
         StarNetworkNode parent,
-        org.eclipse.daanse.rolap.mapping.model.Query relOrJoin,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relOrJoin,
         String foreignKey,
         String joinKey,
         String joinKeyTable)
     {
         if (relOrJoin == null) {
             return null;
-        } else if (relOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery rel) {
+        } else if (!(relOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource)
+                   && relOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel) {
             int val = 0;
             String newAlias =
                 joinKeyTable != null ? joinKeyTable : RelationUtil.getAlias(rel);
@@ -431,7 +434,7 @@ public class RolapStar {
                 StarNetworkNode node = nodeLookup.get(newAlias);
                 if (node == null) {
                     if (val != 0) {
-                        rel = (org.eclipse.daanse.rolap.mapping.model.RelationalQuery)
+                        rel = (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource)
                             cloneRelation(rel, newAlias);
                     }
                     node =
@@ -446,12 +449,12 @@ public class RolapStar {
                 }
                 newAlias = new StringBuilder(RelationUtil.getAlias(rel)).append("_").append(++val).toString();
             }
-        } else if (relOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
-            if (left(join) instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery) {
+        } else if (relOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+            if (left(join) instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) {
                 throw new OlapRuntimeException(illegalLeftDeepJoin);
             }
-            final org.eclipse.daanse.rolap.mapping.model.Query left;
-            final org.eclipse.daanse.rolap.mapping.model.Query right;
+            final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left;
+            final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right;
             if (getLeftAlias(join).equals(joinKeyTable)) {
                 // first manage left then right
                 left =
@@ -459,7 +462,7 @@ public class RolapStar {
                         parent, left(join), foreignKey,
                         joinKey, joinKeyTable);
                 parent = nodeLookup.get(
-                    RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.RelationalQuery) left)));
+                    RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) left)));
                 right =
                     getUniqueRelation(
                         parent, right(join), join.getLeft().getKey() != null ? join.getLeft().getKey().getName() : null,
@@ -471,7 +474,7 @@ public class RolapStar {
                         parent, right(join), foreignKey,
                         joinKey, joinKeyTable);
                 parent = nodeLookup.get(
-                    RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.RelationalQuery) right)));
+                    RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) right)));
                 left =
                     getUniqueRelation(
                         parent, left(join), join.getRight().getKey() != null ? join.getRight().getKey().getName() : null,
@@ -482,15 +485,15 @@ public class RolapStar {
             }
 
             if (left(join) != left || right(join) != right) {
-                JoinQuery joinNew = RolapMappingFactory.eINSTANCE.createJoinQuery();
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource joinNew = SourceFactory.eINSTANCE.createJoinSource();
 
-                org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement leftElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
-                leftElement.setAlias(left instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation ? RelationUtil.getAlias(relation) : null);
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement leftElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
+                leftElement.setAlias(left instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation ? RelationUtil.getAlias(relation) : null);
                 leftElement.setKey(PojoUtil.getColumn(join.getLeft().getKey()));
                 leftElement.setQuery(PojoUtil.copy(left));
 
-                org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement rightElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
-                rightElement.setAlias(right instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation ? RelationUtil.getAlias(relation) : null);
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement rightElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
+                rightElement.setAlias(right instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation ? RelationUtil.getAlias(relation) : null);
                 rightElement.setKey(PojoUtil.getColumn(join.getRight().getKey()));
                 rightElement.setQuery(PojoUtil.copy(right));
                 
@@ -1316,7 +1319,7 @@ public class RolapStar {
      */
     public static class Table {
         private final RolapStar star;
-        private final org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation;
+        private final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation;
         private final List<Column> columnList;
         private final Table parent;
         private List<Table> children;
@@ -1325,7 +1328,7 @@ public class RolapStar {
 
         private Table(
             RolapStar star,
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
             Table parent,
             Condition joinCondition)
         {
@@ -1390,7 +1393,7 @@ public class RolapStar {
             List<Column> l = new ArrayList<>();
             for (Column column : getColumns()) {
                 if (column.getExpression() instanceof org.eclipse.daanse.rolap.element.RolapColumn columnExpr) {
-                    if (columnExpr.getName().equals(columnName)) {
+                    if (java.util.Objects.equals(columnExpr.getName(), columnName)) {
                         l.add(column);
                     }
                 } else if (column.getExpression() != null && column.getExpression().toString().equals(columnName))
@@ -1404,7 +1407,7 @@ public class RolapStar {
         public Column lookupColumn(String columnName) {
             for (Column column : getColumns()) {
                 if (column.getExpression() instanceof org.eclipse.daanse.rolap.element.RolapColumn columnExpr) {
-                    if (columnExpr.getName().equals(columnName)) {
+                    if (java.util.Objects.equals(columnExpr.getName(), columnName)) {
                         return column;
                     }
                 } else if (column.getExpression() != null)
@@ -1412,7 +1415,7 @@ public class RolapStar {
                     if (column.getExpression().toString().equals(columnName)) {
                         return column;
                     }
-                } else if (column.getName().equals(columnName)) {
+                } else if (java.util.Objects.equals(column.getName(), columnName)) {
                     return column;
                 }
             }
@@ -1459,7 +1462,7 @@ public class RolapStar {
         private SqlQuery getSqlQuery() {
             return getStar().getSqlQuery();
         }
-        public org.eclipse.daanse.rolap.mapping.model.RelationalQuery getRelation() {
+        public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getRelation() {
             return relation;
         }
 
@@ -1486,15 +1489,15 @@ public class RolapStar {
          * been given an alias.
          */
         public String getTableName() {
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery t) {
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource t) {
                 return t.getTable().getName();
             } else {
                 return null;
             }
         }
 
-        public org.eclipse.daanse.rolap.mapping.model.Table getTable() {
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery t) {
+        public org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet getTable() {
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource t) {
                 return t.getTable();
             } else {
                 return null;
@@ -1758,28 +1761,16 @@ public class RolapStar {
          */
         public synchronized Table addJoin(
             RolapCube cube,
-            org.eclipse.daanse.rolap.mapping.model.Query relationOrJoin,
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationOrJoin,
             RolapStar.Condition joinCondition)
         {
-            if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relationInner) {
-                RolapStar.Table starTable =
-                    findChild(relationInner, joinCondition);
-                if (starTable == null) {
-                    starTable = new RolapStar.Table(
-                        star, relationInner, this, joinCondition);
-                    if (this.children.isEmpty()) {
-                        this.children = new ArrayList<>();
-                    }
-                    this.children.add(starTable);
-                }
-                return starTable;
-            } else if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+            if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
                 RolapStar.Table leftTable =
                     addJoin(cube, left(join), joinCondition);
                 String leftAlias = getLeftAlias(join);
                 if (leftAlias == null) {
                     // REVIEW: is cast to Relation valid?
-                    leftAlias = RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.RelationalQuery) left(join)));
+                    leftAlias = RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) left(join)));
                     if (leftAlias == null) {
                         throw Util.newError(
                             "missing leftKeyAlias in " + relationOrJoin);
@@ -1794,14 +1785,14 @@ public class RolapStar {
                     // the right relation of a join may be a join
                     // if so, we need to use the right relation join's
                     // left relation's alias.
-                    if (right(join) instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery joinright) {
+                    if (right(join) instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource joinright) {
                         // REVIEW: is cast to Relation valid?
                         rightAlias =
-                            RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.RelationalQuery) left(joinright)));
+                            RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) left(joinright)));
                     } else {
                         // REVIEW: is cast to Relation valid?
                         rightAlias =
-                            RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.RelationalQuery) right(join)));
+                            RelationUtil.getAlias(((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) right(join)));
                     }
                     if (rightAlias == null) {
                         throw Util.newError(
@@ -1814,6 +1805,19 @@ public class RolapStar {
                 return leftTable.addJoin(
                     cube, right(join), joinCondition);
 
+            } else if (relationOrJoin != null) {
+                org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationInner = relationOrJoin;
+                RolapStar.Table starTable =
+                    findChild(relationInner, joinCondition);
+                if (starTable == null) {
+                    starTable = new RolapStar.Table(
+                        star, relationInner, this, joinCondition);
+                    if (this.children.isEmpty()) {
+                        this.children = new ArrayList<>();
+                    }
+                    this.children.add(starTable);
+                }
+                return starTable;
             } else {
                 throw Util.newInternal("bad relation type " + relationOrJoin);
             }
@@ -1824,7 +1828,7 @@ public class RolapStar {
          * if there is none.
          */
         public Table findChild(
-        		org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation,
+        		org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
             Condition joinCondition)
         {
             for (Table child : getChildren()) {
@@ -1875,7 +1879,7 @@ public class RolapStar {
         }
 
         public boolean equalsTableName(String tableName) {
-            return (this.relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mt && mt.getTable().getName().equals(tableName));
+            return (this.relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mt && mt.getTable().getName().equals(tableName));
         }
 
         /**
@@ -2020,12 +2024,14 @@ public class RolapStar {
          * Returns whether this table has a column with the given name.
          */
         public boolean containsColumn(String columnName) {
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery) {
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) {
+                // todo: Deal with join.
+                return false;
+            } else if (relation != null) {
                 return containsColumn(
                     RelationUtil.getAlias((relation)),
                     columnName);
             } else {
-                // todo: Deal with join.
                 return false;
             }
         }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapStarRegistry.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapStarRegistry.java
@@ -59,7 +59,7 @@ public class RolapStarRegistry {
 	 *
 	 * {@link RolapStar.Table#addJoin} works in a similar way.
 	 */
-	public synchronized RolapStar getOrCreateStar(final org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact) {
+	public synchronized RolapStar getOrCreateStar(final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact) {
 		final List<String> rolapStarKey = RolapUtil.makeRolapStarKey(fact);
 		RolapStar star = stars.get(rolapStarKey);
 		if (star == null) {
@@ -79,7 +79,7 @@ public class RolapStarRegistry {
 		return getStar(makeRolapStarKey(factTableName));
 	}
 
-	public RolapStar makeRolapStar(final org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact) {
+	public RolapStar makeRolapStar(final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact) {
 		return new RolapStar(schema, context, fact);
 	}
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/CalculatedMemberUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/CalculatedMemberUtil.java
@@ -20,7 +20,7 @@ public class CalculatedMemberUtil {
     private CalculatedMemberUtil() {
     }
 
-    public static String getFormula(org.eclipse.daanse.rolap.mapping.model.CalculatedMember calculatedMember) {
+    public static String getFormula(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember calculatedMember) {
     	return calculatedMember.getFormula();
     }
 
@@ -29,8 +29,8 @@ public class CalculatedMemberUtil {
      * "FORMAT_STRING" first, then looking for an attribute called
      * "formatString".
      */
-    public static String getFormatString(org.eclipse.daanse.rolap.mapping.model.CalculatedMember calculatedMember) {
-        for (org.eclipse.daanse.rolap.mapping.model.CalculatedMemberProperty prop : calculatedMember.getCalculatedMemberProperties()) {
+    public static String getFormatString(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember calculatedMember) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMemberProperty prop : calculatedMember.getCalculatedMemberProperties()) {
             if (prop.getName().equals(
                 StandardProperty.FORMAT_STRING.getName()))
             {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/DimensionTypeUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/DimensionTypeUtil.java
@@ -22,11 +22,11 @@ public class DimensionTypeUtil {
     }
 
     // Return the dimension's enumerated type.
-    public static DimensionType getDimensionType(org.eclipse.daanse.rolap.mapping.model.Dimension dimension) {
-        if (dimension instanceof org.eclipse.daanse.rolap.mapping.model.StandardDimension) {
+    public static DimensionType getDimensionType(org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension dimension) {
+        if (dimension instanceof org.eclipse.daanse.rolap.mapping.model.olap.dimension.StandardDimension) {
             return DimensionType.STANDARD_DIMENSION;
         }
-        if (dimension instanceof org.eclipse.daanse.rolap.mapping.model.TimeDimension) {
+        if (dimension instanceof org.eclipse.daanse.rolap.mapping.model.olap.dimension.TimeDimension) {
         	return DimensionType.TIME_DIMENSION;
         }
         return null;

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/DimensionUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/DimensionUtil.java
@@ -23,7 +23,7 @@ public class DimensionUtil {
         // constructor
     }
 
-    public static org.eclipse.daanse.rolap.mapping.model.Dimension getDimension(org.eclipse.daanse.rolap.mapping.model.Catalog schema, org.eclipse.daanse.rolap.mapping.model.DimensionConnector dimension) {
+    public static org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension getDimension(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog schema, org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector dimension) {
     	/*
         if (dimension instanceof MappingDimensionUsage dimensionUsage) {
             Util.assertPrecondition(schema != null, SCHEMA_NULL);
@@ -77,7 +77,7 @@ public class DimensionUtil {
 //        throw Util.newInternal(new StringBuilder("Cannot find cube '").append(cubeName).append("'").toString());
 //    }
 
-    public static org.eclipse.daanse.rolap.mapping.model.Dimension getDimension(org.eclipse.daanse.rolap.mapping.model.PhysicalCube cube, org.eclipse.daanse.rolap.mapping.model.Catalog schema, String dimensionName) {
+    public static org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension getDimension(org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube cube, org.eclipse.daanse.rolap.mapping.model.catalog.Catalog schema, String dimensionName) {
         for (int i = 0; i < cube.getDimensionConnectors().size(); i++) {
             if (cube.getDimensionConnectors().get(i).getOverrideDimensionName().equals(dimensionName)) {
                 return getDimension(schema, cube.getDimensionConnectors().get(i));

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/JoinUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/JoinUtil.java
@@ -22,21 +22,21 @@ public class JoinUtil {
         // constructor
     }
 
-    public static org.eclipse.daanse.rolap.mapping.model.Query left(org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+    public static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left(org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
         if (join != null && join.getLeft() != null) {
             return join.getLeft().getQuery();
         }
         throw new RolapRuntimeException("Join left error");
     }
 
-    public static org.eclipse.daanse.rolap.mapping.model.Query right(org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+    public static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right(org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
         if (join != null && join.getRight() != null) {
             return join.getRight().getQuery();
         }
         throw new RolapRuntimeException("Join right error");
     }
 
-    public static void changeLeftRight(org.eclipse.daanse.rolap.mapping.model.JoinQuery join, org.eclipse.daanse.rolap.mapping.model.Query left, org.eclipse.daanse.rolap.mapping.model.Query right) {
+    public static void changeLeftRight(org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join, org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left, org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right) {
         join.getLeft().setQuery(left);
         join.getRight().setQuery(right);
     }
@@ -45,13 +45,16 @@ public class JoinUtil {
      * Returns the alias of the left join key, defaulting to left's
      * alias if left is a table.
      */
-    public static String getLeftAlias(org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+    public static String getLeftAlias(org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
         if (join.getLeft() != null && join.getLeft().getAlias() != null) {
             return join.getLeft().getAlias();
         }
-        org.eclipse.daanse.rolap.mapping.model.Query left = left(join);
-        if (left instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
-            return RelationUtil.getAlias(relation);
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left = left(join);
+        if (left instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource innerJoin) {
+            return getLeftAlias(innerJoin);
+        }
+        if (left != null) {
+            return RelationUtil.getAlias(left);
         }
         throw Util.newInternal(
             new StringBuilder("alias is required because ").append(left).append(" is not a table").toString());
@@ -61,16 +64,16 @@ public class JoinUtil {
      * Returns the alias of the right join key, defaulting to right's
      * alias if right is a table.
      */
-    public static String getRightAlias(org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+    public static String getRightAlias(org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
         if (join.getRight() != null && join.getRight().getAlias() != null) {
             return join.getRight().getAlias();
         }
-        org.eclipse.daanse.rolap.mapping.model.Query right = right(join);
-        if (right instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
-            return RelationUtil.getAlias(relation);
-        }
-        if (right instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery j) {
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right = right(join);
+        if (right instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource j) {
             return getLeftAlias(j);
+        }
+        if (right != null) {
+            return RelationUtil.getAlias(right);
         }
         throw Util.newInternal(
             new StringBuilder("alias is required because ").append(right).append(" is not a table").toString());

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/LevelUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/LevelUtil.java
@@ -16,10 +16,14 @@ package org.eclipse.daanse.rolap.common.util;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.ColumnSet;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet;
+import org.eclipse.daanse.cwm.util.resource.relational.Columns;
 import org.eclipse.daanse.olap.api.sql.SortingDirection;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
 import org.eclipse.daanse.rolap.common.star.RolapSqlExpression;
 import org.eclipse.daanse.rolap.element.RolapColumn;
+import org.eclipse.daanse.rolap.element.RolapHierarchy;
 
 public class LevelUtil {
 
@@ -27,67 +31,105 @@ public class LevelUtil {
         // constructor
     }
 
-    public static SqlExpression getKeyExp(org.eclipse.daanse.rolap.mapping.model.Level level) {
-        if (level.getColumn() instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn sec) {
+    public static SqlExpression getKeyExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level) {
+        return getKeyExp(level, null);
+    }
+
+    public static SqlExpression getKeyExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, RolapHierarchy hierarchy) {
+        if (level.getColumn() instanceof org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn sec) {
             return new RolapSqlExpression(sec);
         } else if (level.getColumn() != null) {
-            return new RolapColumn(getTableName(level.getColumn().getTable()), level.getColumn().getName());
+            return new RolapColumn(ownerAlias(hierarchy, level.getColumn()), level.getColumn().getName());
         } else {
             return null;
         }
     }
 
-    public static RolapSqlExpression getNameExp(org.eclipse.daanse.rolap.mapping.model.Level level) {
-        if (level.getNameColumn() instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn sec) {
+    public static RolapSqlExpression getNameExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level) {
+        return getNameExp(level, null);
+    }
+
+    public static RolapSqlExpression getNameExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, RolapHierarchy hierarchy) {
+        if (level.getNameColumn() instanceof org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn sec) {
             return new RolapSqlExpression(sec);
         } else if (level.getNameColumn() != null && !Objects.equals(level.getNameColumn(), level.getColumn())) {
-            return new RolapColumn(getTableName(level.getColumn().getTable()), level.getNameColumn().getName());
+            return new RolapColumn(ownerAlias(hierarchy, level.getColumn()), level.getNameColumn().getName());
         } else {
             return null;
         }
     }
 
-    private static String getTableName(org.eclipse.daanse.rolap.mapping.model.Table table) {
+    private static String getTableName(org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table) {
         if (table != null) {
             return table.getName();
         }
         return null;
-	}
+    }
 
-	public static RolapSqlExpression getCaptionExp(org.eclipse.daanse.rolap.mapping.model.Level level) {
-	    if (level.getCaptionColumn() instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn sec) {
+    /**
+     * Returns the alias used by the given hierarchy's join tree to reference the
+     * column's owner table/view. Falls back to the owner's bare name when no
+     * hierarchy context is available or when the owner is not found in the tree.
+     */
+    private static String ownerAlias(RolapHierarchy hierarchy,
+            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
+        ColumnSet owner = Columns.owner(column).orElse(null);
+        if (hierarchy != null && owner instanceof NamedColumnSet named) {
+            return hierarchy.findAliasForOwner(named);
+        }
+        return owner != null ? owner.getName() : null;
+    }
+
+	public static RolapSqlExpression getCaptionExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level) {
+        return getCaptionExp(level, null);
+    }
+
+    public static RolapSqlExpression getCaptionExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, RolapHierarchy hierarchy) {
+	    if (level.getCaptionColumn() instanceof org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn sec) {
             return new RolapSqlExpression(sec);
         } else if (level.getCaptionColumn() != null) {
-            return new RolapColumn(getTableName(level.getColumn().getTable()), level.getCaptionColumn().getName());
+            return new RolapColumn(ownerAlias(hierarchy, level.getColumn()), level.getCaptionColumn().getName());
         } else {
             return null;
         }
     }
 
-    public static List<? extends SqlExpression> getOrdinalExp(org.eclipse.daanse.rolap.mapping.model.Level level) {
+    public static List<? extends SqlExpression> getOrdinalExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level) {
+        return getOrdinalExp(level, null);
+    }
+
+    public static List<? extends SqlExpression> getOrdinalExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, RolapHierarchy hierarchy) {
         if (level.getOrdinalColumns() != null && !level.getOrdinalColumns().isEmpty()) {
             return level.getOrdinalColumns().stream().filter(oc -> oc.getColumn() != null).map(oc -> {
-                if (oc.getColumn() instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn sec) {
+                if (oc.getColumn() instanceof org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn sec) {
                     return new RolapSqlExpression(sec, SortingDirection.valueOf(oc.getDirection().name()));
                 }
-                return new RolapColumn(getTableName(level.getColumn().getTable()), oc.getColumn().getName(), SortingDirection.valueOf(oc.getDirection().getName()));
+                return new RolapColumn(ownerAlias(hierarchy, level.getColumn()), oc.getColumn().getName(), SortingDirection.valueOf(oc.getDirection().getName()));
             }).toList();
         } else {
             return List.of();
         }
     }
 
-    public static RolapSqlExpression getParentExp(org.eclipse.daanse.rolap.mapping.model.ParentChildHierarchy hierarchy) {
-        if (hierarchy.getParentColumn() instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn sec) {
+    public static RolapSqlExpression getParentExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildHierarchy hierarchy) {
+        return getParentExp(hierarchy, null);
+    }
+
+    public static RolapSqlExpression getParentExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildHierarchy hierarchy, RolapHierarchy rolapHierarchy) {
+        if (hierarchy.getParentColumn() instanceof org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn sec) {
             return new RolapSqlExpression(sec);
         } else if (hierarchy.getParentColumn() != null) {
-            return new RolapColumn(getTableName(hierarchy.getParentColumn().getTable()), hierarchy.getParentColumn().getName());
+            return new RolapColumn(ownerAlias(rolapHierarchy, hierarchy.getParentColumn()), hierarchy.getParentColumn().getName());
         } else {
             return null;
         }
     }
 
-    public static RolapSqlExpression getPropertyExp(org.eclipse.daanse.rolap.mapping.model.Level level, int i) {
-        return new RolapColumn(getTableName(level.getColumn().getTable()), level.getMemberProperties().get(i).getColumn().getName());
+    public static RolapSqlExpression getPropertyExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, int i) {
+        return getPropertyExp(level, i, null);
+    }
+
+    public static RolapSqlExpression getPropertyExp(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, int i, RolapHierarchy hierarchy) {
+        return new RolapColumn(ownerAlias(hierarchy, level.getColumn()), level.getMemberProperties().get(i).getColumn().getName());
     }
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/PojoUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/PojoUtil.java
@@ -21,9 +21,11 @@ import static org.eclipse.daanse.rolap.common.util.JoinUtil.right;
 import java.util.List;
 
 import org.eclipse.daanse.olap.common.Util;
-import org.eclipse.daanse.rolap.mapping.model.Query;
+import org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 
+import org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 public class PojoUtil {
 	public static final String BAD_RELATION_TYPE = "bad relation type ";
 	private PojoUtil() {
@@ -36,13 +38,13 @@ public class PojoUtil {
 //					.withsSchema(getDatabaseSchema(s.getSchema()))
 //					.withColumns(getColumns(s.getColumns()))
 //					.withName(s.getName()))
-//					.withSqlStatements(getSqlStatements(s.getSqlStatements()))
+//					.withSqlStatements(getSqlStatements(s.getDialectStatements()))
 //					.build();
 //		}
 //		return null;
 //	}
 
-    private static org.eclipse.daanse.rolap.mapping.model.SqlStatement getSql(org.eclipse.daanse.rolap.mapping.model.SqlStatement s) {
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement getSql(org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement s) {
         if (s != null) {
             //return SqlStatementMappingImpl.builder()
             //    .withDialects(s.getDialects())
@@ -77,16 +79,16 @@ public class PojoUtil {
      *
      * @param relation A table or a join
      */
-    public static org.eclipse.daanse.rolap.mapping.model.Query copy(
-         org.eclipse.daanse.rolap.mapping.model.Query relation)
+    public static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource copy(
+         org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation)
     {
         return switch (relation) {
-        case org.eclipse.daanse.rolap.mapping.model.TableQuery table -> {
-        	org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlMappingImpl = getSql(table.getSqlWhereExpression());
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationExclude> aggregationExcludes = getAggregationExcludes(table.getAggregationExcludes());
-            List<? extends org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint> optimizationHints = getOptimizationHints(table.getOptimizationHints());
-            List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationTable> aggregationTables = getAggregationTables(table.getAggregationTables());
-            org.eclipse.daanse.rolap.mapping.model.TableQuery q = RolapMappingFactory.eINSTANCE.createTableQuery();
+        case org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table -> {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlMappingImpl = getSql(table.getSqlWhereExpression());
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude> aggregationExcludes = getAggregationExcludes(table.getAggregationExcludes());
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint> optimizationHints = getOptimizationHints(table.getOptimizationHints());
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable> aggregationTables = getAggregationTables(table.getAggregationTables());
+            org.eclipse.daanse.rolap.mapping.model.database.source.TableSource q = SourceFactory.eINSTANCE.createTableSource();
             q.setAlias(table.getAlias());
             q.setTable(getPhysicalTable(table.getTable()));
             q.setSqlWhereExpression(sqlMappingImpl);
@@ -95,23 +97,23 @@ public class PojoUtil {
             q.getAggregationTables().addAll(aggregationTables);
             yield q;
         }
-        case org.eclipse.daanse.rolap.mapping.model.InlineTableQuery table -> {
-            org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTableQuery = RolapMappingFactory.eINSTANCE.createInlineTableQuery();
+        case org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource table -> {
+            org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTableQuery = SourceFactory.eINSTANCE.createInlineTableSource();
             inlineTableQuery.setAlias(table.getAlias());
             inlineTableQuery.setTable(getInlineTable(table.getTable()));
             yield inlineTableQuery;
         }
-        case org.eclipse.daanse.rolap.mapping.model.JoinQuery join -> {
-            org.eclipse.daanse.rolap.mapping.model.Query left = copy(left(join));
-            org.eclipse.daanse.rolap.mapping.model.Query right = copy(right(join));
-            org.eclipse.daanse.rolap.mapping.model.JoinQuery joinQuery = RolapMappingFactory.eINSTANCE.createJoinQuery();
+        case org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join -> {
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left = copy(left(join));
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right = copy(right(join));
+            org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource joinQuery = SourceFactory.eINSTANCE.createJoinSource();
             
-            org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement leftElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+            org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement leftElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
             leftElement.setAlias(getLeftAlias(join));
             leftElement.setKey(getColumn(join.getLeft().getKey()));
             leftElement.setQuery(left);
             
-            org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement rightElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+            org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement rightElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
             rightElement.setAlias(getRightAlias(join));
             rightElement.setKey(getColumn(join.getRight().getKey()));
             rightElement.setQuery(right);
@@ -124,11 +126,11 @@ public class PojoUtil {
         };
     }
 
-	public static org.eclipse.daanse.rolap.mapping.model.InlineTable getInlineTable(org.eclipse.daanse.rolap.mapping.model.InlineTable table) {
+	public static org.eclipse.daanse.rolap.mapping.model.database.relational.InlineTable getInlineTable(org.eclipse.daanse.rolap.mapping.model.database.relational.InlineTable table) {
     	//List<? extends org.eclipse.daanse.rolap.mapping.model.Row> rows = getRows(table.getRows());
-    	//List<? extends org.eclipse.daanse.rolap.mapping.model.Column> columns = getColumns(table.getColumns());
-    	//org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema = getDatabaseSchema(table.getSchema());
-    	//org.eclipse.daanse.rolap.mapping.model.InlineTable inlineTable = InlineTableMappingImpl.builder().build();
+    	//List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> columns = getColumns(table.getFeature().stream().filter(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column.class::isInstance).map(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column.class::cast).toList());
+    	//org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema = getDatabaseSchema(table.getSchema());
+    	//org.eclipse.daanse.rolap.mapping.model.database.relational.InlineTable inlineTable = InlineTableMappingImpl.builder().build();
         //inlineTable.setName(table.getName());
         //inlineTable.setColumns(columns);
         //inlineTable.setSchema(schema);
@@ -138,8 +140,8 @@ public class PojoUtil {
 		return table; //TODO temove method
 	}
 
-	private static List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationTable> getAggregationTables(
-			List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationTable> aggregationTables) {
+	private static List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable> getAggregationTables(
+			List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable> aggregationTables) {
 		if (aggregationTables != null) {
 			//return aggregationTables.stream().map(c -> getAggregationTable(c)).toList();
 			return aggregationTables; //TODO remove
@@ -147,14 +149,14 @@ public class PojoUtil {
 		return List.of();
 	}
 
-	private static org.eclipse.daanse.rolap.mapping.model.AggregationTable getAggregationTable(org.eclipse.daanse.rolap.mapping.model.AggregationTable a) {
-		if (a instanceof org.eclipse.daanse.rolap.mapping.model.AggregationName anm) {
-			org.eclipse.daanse.rolap.mapping.model.AggregationName aggregationName = RolapMappingFactory.eINSTANCE.createAggregationName();
+	private static org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable getAggregationTable(org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable a) {
+		if (a instanceof org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName anm) {
+			org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName aggregationName = AggregationFactory.eINSTANCE.createAggregationName();
 			aggregationName.setApproxRowCount(anm.getApproxRowCount());
 			return aggregationName;
 		}
-		if (a instanceof org.eclipse.daanse.rolap.mapping.model.AggregationPattern apm) {
-			org.eclipse.daanse.rolap.mapping.model.AggregationPattern aggregationPattern = RolapMappingFactory.eINSTANCE.createAggregationPattern();
+		if (a instanceof org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationPattern apm) {
+			org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationPattern aggregationPattern = AggregationFactory.eINSTANCE.createAggregationPattern();
 			aggregationPattern.setPattern(apm.getPattern());
 			aggregationPattern.getAggregationMeasures().addAll(getAggregationMeasures(apm.getAggregationMeasures()));
 			return aggregationPattern;
@@ -162,11 +164,11 @@ public class PojoUtil {
 		return null;
 	}
 
-	private static List<org.eclipse.daanse.rolap.mapping.model.AggregationMeasure> getAggregationMeasures(
-			List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationMeasure> aggregationMeasures) {
+	private static List<org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasure> getAggregationMeasures(
+			List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasure> aggregationMeasures) {
 		if (aggregationMeasures != null) {
 			return aggregationMeasures.stream().map(c -> {
-				org.eclipse.daanse.rolap.mapping.model.AggregationMeasure aggregationMeasure = RolapMappingFactory.eINSTANCE.createAggregationMeasure();
+				org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasure aggregationMeasure = AggregationFactory.eINSTANCE.createAggregationMeasure();
 				aggregationMeasure.setColumn(c.getColumn());
 				aggregationMeasure.setName(c.getName());
 				aggregationMeasure.setRollupType(c.getRollupType());
@@ -176,8 +178,8 @@ public class PojoUtil {
 		return List.of();
 	}
 
-	public static List<? extends org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint> getOptimizationHints(
-			List<? extends org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint> optimizationHints) {
+	public static List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint> getOptimizationHints(
+			List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint> optimizationHints) {
 		if (optimizationHints != null) {
 			//return optimizationHints.stream().map(c -> TableQueryOptimizationHintMappingImpl.builder()
 			//		.withValue(c.getValue())
@@ -189,8 +191,8 @@ public class PojoUtil {
 	}
 
 
-	private static List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationExclude> getAggregationExcludes(
-			List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationExclude> aggregationExcludes) {
+	private static List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude> getAggregationExcludes(
+			List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude> aggregationExcludes) {
     	if (aggregationExcludes != null) {
     		//return aggregationExcludes.stream().map(a ->
     		//AggregationExcludeMappingImpl.builder()
@@ -204,29 +206,28 @@ public class PojoUtil {
     	return List.of();
 	}
 
-	public static List<? extends org.eclipse.daanse.rolap.mapping.model.Row> getRows(List<? extends org.eclipse.daanse.rolap.mapping.model.Row> rows) {
+	public static List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Row> getRows(List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Row> rows) {
     	if (rows != null) {
-    		//return rows.stream().map(r -> ((RowMapping)(RowMappingImpl.builder().withRowValues(getRowValues(r.getRowValues())).build()))).toList();
-    		return rows; 
+    		return rows;
     	}
     	return List.of();
 	}
 
-	private static List<? extends org.eclipse.daanse.rolap.mapping.model.RowValue> getRowValues(List<? extends org.eclipse.daanse.rolap.mapping.model.RowValue> list) {
+	private static List<? extends org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot> getRowValues(List<? extends org.eclipse.daanse.cwm.model.cwm.objectmodel.instance.DataSlot> list) {
 		if (list != null) {
-			//return list.stream().map(c -> RowValueMappingImpl.builder().withValue(c.getValue()).withColumn((PhysicalColumnMappingImpl)getColumn(c.getColumn())).build()).toList();
-			return list; //TODO remove
+			return list;
 		}
-		return List.of();	}
+		return List.of();
+	}
 
-	private static org.eclipse.daanse.rolap.mapping.model.DatabaseSchema getDatabaseSchema(org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema) {
+	private static org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema getDatabaseSchema(org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema) {
         if (schema != null) {
             return schema; //TODO remove
         }
         return null;
 	}
 
-	private static List<org.eclipse.daanse.rolap.mapping.model.Column> getColumns(List<? extends org.eclipse.daanse.rolap.mapping.model.Column> columns) {
+	private static List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> getColumns(List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> columns) {
 		if (columns != null) {
             return columns.stream().map(c -> getColumn(c)).toList();
         }
@@ -234,18 +235,18 @@ public class PojoUtil {
 	}
 
 	// TODO: migrate to util.Converter
-	public static org.eclipse.daanse.rolap.mapping.model.Column getColumn(org.eclipse.daanse.rolap.mapping.model.Column column) {
+	public static org.eclipse.daanse.cwm.model.cwm.resource.relational.Column getColumn(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
         if (column != null) {
             /*
             String name = column.getName();
             ColumnType type = column.getType();
-            Integer columnSize = column.getColumnSize();
-            Integer decimalDigits = column.getDecimalDigits();
-            Integer numPrecRadix = column.getNumPrecRadix();
-            Integer charOctetLength = column.getCharOctetLength();
-            Boolean nullable = column.getNullable();
+            Integer columnSize = (column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst ? _sst.getCharacterMaximumLength() : null);
+            Integer decimalDigits = (column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst2 ? _sst2.getNumericScale() : null);
+            Integer numPrecRadix = (column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst3 ? _sst3.getNumericPrecisionRadix() : null);
+            Integer charOctetLength = (column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst4 ? _sst4.getCharacterOctetLength() : null);
+            Boolean nullable = (column.getIsNullable() != null ? column.getIsNullable().getValue() == 1 : null);
             String description = column.getDescription();
-            org.eclipse.daanse.rolap.mapping.model.PhysicalColumn c = PhysicalColumnMappingImpl.builder().withName(name).withDataType(type)
+            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column c = PhysicalColumnMappingImpl.builder().withName(name).withDataType(type)
                     .withColumnSize(orZero(columnSize))
                     .withDecimalDigits(orZero(decimalDigits))
                     .withNumPrecRadix(orZero(numPrecRadix))
@@ -263,16 +264,16 @@ public class PojoUtil {
     }
 
     // TODO: migrate to util.Converter
-	public static org.eclipse.daanse.rolap.mapping.model.Table getPhysicalTable(org.eclipse.daanse.rolap.mapping.model.Table table) {
+	public static org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet getPhysicalTable(org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table) {
 		if (table != null) {
             //String name = table.getName();
-            //List<org.eclipse.daanse.rolap.mapping.model.Column> columns = getColumns(table.getColumns());
-            //org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema = getDatabaseSchema(table.getSchema());
+            //List<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> columns = getColumns(table.getFeature().stream().filter(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column.class::isInstance).map(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column.class::cast).toList());
+            //org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema = getDatabaseSchema(table.getSchema());
             //String description = table.getDescription();
-            //org.eclipse.daanse.rolap.mapping.model.PhysicalTable t = ((PhysicalTableMappingImpl.Builder) PhysicalTableMappingImpl.builder()
+            //org.eclipse.daanse.cwm.model.cwm.resource.relational.Table t = ((PhysicalTableMappingImpl.Builder) PhysicalTableMappingImpl.builder()
             //        .withName(name).withColumns(columns).withsSchema(schema).withsDdescription(description)).build();
             //if (t.getColumns() != null) {
-            //    t.getColumns().forEach(c -> ((org.eclipse.daanse.rolap.mapping.model.PhysicalColumn)c).setTable(table));
+            //    t.getColumns().forEach(c -> ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Column)c).setTable(table));
             //}
             //return t;
 			return table;

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/RelationUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/RelationUtil.java
@@ -26,31 +26,31 @@ public class RelationUtil {
         // constructor
     }
 
-    public static org.eclipse.daanse.rolap.mapping.model.RelationalQuery find(org.eclipse.daanse.rolap.mapping.model.Query relationOrJoin, String tableName) {
+    public static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource find(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationOrJoin, String tableName) {
         switch (relationOrJoin) {
-        case org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTable -> {
-            return tableName.equals(inlineTable.getAlias()) ? (org.eclipse.daanse.rolap.mapping.model.RelationalQuery) relationOrJoin : null;
+        case org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTable -> {
+            return tableName.equals(inlineTable.getAlias()) ? (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) relationOrJoin : null;
         }
-        case org.eclipse.daanse.rolap.mapping.model.TableQuery table -> {
+        case org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table -> {
             if (tableName.equals(table.getTable().getName())) {
-                return (org.eclipse.daanse.rolap.mapping.model.RelationalQuery) relationOrJoin;
+                return (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) relationOrJoin;
             } else {
                     return null; //old version of code had wrong condition with equals
             }
         }
-        case org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view -> {
+        case org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view -> {
             if (tableName.equals(view.getAlias())) {
-                return (org.eclipse.daanse.rolap.mapping.model.RelationalQuery) relationOrJoin;
+                return (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) relationOrJoin;
             } else {
                 return null;
             }
         }
-        case org.eclipse.daanse.rolap.mapping.model.JoinQuery join -> {
-        	org.eclipse.daanse.rolap.mapping.model.Query relation = find(left(join), tableName);
+        case org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join -> {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = find(left(join), tableName);
             if (relation == null) {
                 relation = find(right(join), tableName);
             }
-            return (org.eclipse.daanse.rolap.mapping.model.RelationalQuery) relation;
+            return (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) relation;
         }
         case null, default -> {
         }
@@ -59,8 +59,8 @@ public class RelationUtil {
         throw new RolapRuntimeException("Rlation: find error");
     }
 
-    public static String getAlias(org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+    public static String getAlias(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
             return (table.getAlias() != null) ? table.getAlias() : table.getTable() != null ? table.getTable().getName() : null;
         }
         else {
@@ -68,8 +68,8 @@ public class RelationUtil {
         }
     }
 
-    public static String getTableName(org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+    public static String getTableName(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
             return table.getTable() != null ? table.getTable().getName() : null;
         }
         else {
@@ -77,30 +77,30 @@ public class RelationUtil {
         }
     }
 
-    public static boolean equals(org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation, Object o) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view) {
-            if (o instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery that) {
+    public static boolean equals(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation, Object o) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view) {
+            if (o instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource that) {
                 if (!Objects.equals(relation.getAlias(), that.getAlias())) {
                     return false;
                 }
                 if (
                     view.getSql() == null || that.getSql() == null
-                    || view.getSql().getSqlStatements() == null || that.getSql().getSqlStatements() == null
-                    || view.getSql().getSqlStatements().size() != that.getSql().getSqlStatements().size()) {
+                    || view.getSql().getDialectStatements() == null || that.getSql().getDialectStatements() == null
+                    || view.getSql().getDialectStatements().size() != that.getSql().getDialectStatements().size()) {
                     return false;
                 }
-                for (int i = 0; i < view.getSql().getSqlStatements().size(); i++) {
-                    if (view.getSql().getSqlStatements().get(i).getSql() == null || that.getSql().getSqlStatements().get(i).getSql() == null || 
-                    		!Objects.equals(view.getSql().getSqlStatements().get(i).getSql(), that.getSql().getSqlStatements().get(i).getSql()))
+                for (int i = 0; i < view.getSql().getDialectStatements().size(); i++) {
+                    if (view.getSql().getDialectStatements().get(i).getSql() == null || that.getSql().getDialectStatements().get(i).getSql() == null || 
+                    		!Objects.equals(view.getSql().getDialectStatements().get(i).getSql(), that.getSql().getDialectStatements().get(i).getSql()))
                     {
                         return false;
                     }
-                    if (view.getSql().getSqlStatements().get(i).getDialects() == null || that.getSql().getSqlStatements().get(i).getDialects() == null
-                        || view.getSql().getSqlStatements().get(i).getDialects().size() != that.getSql().getSqlStatements().get(i).getDialects().size()) {
+                    if (view.getSql().getDialectStatements().get(i).getDialects() == null || that.getSql().getDialectStatements().get(i).getDialects() == null
+                        || view.getSql().getDialectStatements().get(i).getDialects().size() != that.getSql().getDialectStatements().get(i).getDialects().size()) {
                         return false;
                     }
-                    for (int j = 0; j< view.getSql().getSqlStatements().get(i).getDialects().size(); j++) {
-                        if (!view.getSql().getSqlStatements().get(i).getDialects().get(j).equals(that.getSql().getSqlStatements().get(i).getDialects().get(j))) {
+                    for (int j = 0; j< view.getSql().getDialectStatements().get(i).getDialects().size(); j++) {
+                        if (!view.getSql().getDialectStatements().get(i).getDialects().get(j).equals(that.getSql().getDialectStatements().get(i).getDialects().get(j))) {
                             return false;
                         }
                     }
@@ -111,18 +111,18 @@ public class RelationUtil {
                 return false;
             }
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
-            if (o instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery that) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
+            if (o instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource that) {
                 return table.getTable() != null &&  that.getTable() != null && 
                 	table.getTable().getName().equals(that.getTable().getName()) &&
                     Objects.equals(relation.getAlias(), that.getAlias()) &&
-                    Objects.equals(table.getTable().getSchema(), that.getTable().getSchema());
+                    Objects.equals(table.getTable().getNamespace(), that.getTable().getNamespace());
             } else {
                 return false;
             }
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery) {
-            if (o instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery that) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource) {
+            if (o instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource that) {
                 return relation.getAlias().equals(that.getAlias());
             } else {
                 return false;
@@ -132,28 +132,28 @@ public class RelationUtil {
         return relation == o;
     }
 
-    public static int hashCode(org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery) {
+    public static int hashCode(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource) {
             return toString(relation).hashCode();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource) {
             return toString(relation).hashCode();
         }
         return System.identityHashCode(relation);
     }
 
-    private static Object toString(org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
-            return (table.getTable().getSchema() == null || table.getTable().getSchema().getName() == null) ?
+    private static Object toString(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
+            return (table.getTable().getNamespace() == null || table.getTable().getNamespace().getName() == null) ?
                 table.getTable().getName() :
-                new StringBuilder(table.getTable().getSchema().getName()).append(".").append(table.getTable().getName()).toString();
+                new StringBuilder(table.getTable().getNamespace().getName()).append(".").append(table.getTable().getName()).toString();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
             return new StringBuilder("(").append(left(join)).append(") join (").append(right(join)).append(") on ")
                 .append(join.getLeft().getAlias()).append(".").append(join.getLeft().getKey()).append(" = ")
                 .append(join.getRight().getAlias()).append(".").append(join.getRight().getKey()).toString();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource) {
             return "<inline data>";
         }
         return relation.toString();

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/SQLUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/SQLUtil.java
@@ -23,9 +23,9 @@ public class SQLUtil {
      * Converts an array of SQL to a
      * {@link org.eclipse.daanse.rolap.common.sql.SqlQuery.CodeSet} object.
      */
-    public static SqlQuery.CodeSet toCodeSetSqlStatement(List<? extends org.eclipse.daanse.rolap.mapping.model.SqlStatement> sqls) {
+    public static SqlQuery.CodeSet toCodeSetSqlStatement(List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement> sqls) {
         SqlQuery.CodeSet codeSet = new SqlQuery.CodeSet();
-        for (org.eclipse.daanse.rolap.mapping.model.SqlStatement sql : sqls) {
+        for (org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sql : sqls) {
             for (String dialect : sql.getDialects()) {
                 codeSet.put(dialect, sql.getSql());
             }
@@ -47,8 +47,8 @@ public class SQLUtil {
         return sql.getDialects().hashCode();
     }
 
-    public boolean equals(org.eclipse.daanse.rolap.mapping.model.SqlStatement sql, Object obj) {
-        if (!(obj instanceof org.eclipse.daanse.rolap.mapping.model.SqlStatement that)) {
+    public boolean equals(org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sql, Object obj) {
+        if (!(obj instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement that)) {
             return false;
         }
         if (sql.getDialects().size() != that.getDialects().size()) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/TableUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/TableUtil.java
@@ -18,16 +18,16 @@ import java.util.stream.Collectors;
 
 
 public class TableUtil {
-	public static Map<String, String> getHintMap(org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+	public static Map<String, String> getHintMap(org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
 
 		if (table.getOptimizationHints() == null) {
 			return Map.of();
 		}
 		return table.getOptimizationHints().stream()
-				.collect(Collectors.toMap(org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint::getType, org.eclipse.daanse.rolap.mapping.model.TableQueryOptimizationHint::getValue));
+				.collect(Collectors.toMap(org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint::getType, org.eclipse.daanse.rolap.mapping.model.database.source.TableQueryOptimizationHint::getValue));
 	}
 
-    public static String getFilter(org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+    public static String getFilter(org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
         return (table.getSqlWhereExpression() == null) ? null : table.getSqlWhereExpression().getSql();
     }
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/util/ViewUtil.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/util/ViewUtil.java
@@ -18,8 +18,8 @@ import static org.eclipse.daanse.rolap.common.util.SQLUtil.toCodeSetSqlStatement
 import org.eclipse.daanse.rolap.common.sql.SqlQuery;
 
 public class ViewUtil {
-    public static SqlQuery.CodeSet getCodeSet(org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery view) {
-        return toCodeSetSqlStatement(view.getSql().getSqlStatements());
+    public static SqlQuery.CodeSet getCodeSet(org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource view) {
+        return toCodeSetSqlStatement(view.getSql().getDialectStatements());
     }
 
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackAttribute.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackAttribute.java
@@ -33,7 +33,7 @@ public class RolapWritebackAttribute extends RolapWritebackColumn {
 
     public RolapWritebackAttribute(
             Dimension dimension,
-            org.eclipse.daanse.rolap.mapping.model.Column column
+            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column
     ) {
         super(column);
         this.dimension = dimension;

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackColumn.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackColumn.java
@@ -33,7 +33,7 @@ public abstract class RolapWritebackColumn{
 
     protected final RolapDatabaseColumn column;
 
-    protected RolapWritebackColumn(org.eclipse.daanse.rolap.mapping.model.Column column) {
+    protected RolapWritebackColumn(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
         this.column = new RolapDatabaseColumn();
         this.column.setName(column.getName());
     }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackMeasure.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackMeasure.java
@@ -33,7 +33,7 @@ public class RolapWritebackMeasure  extends RolapWritebackColumn {
 
     public RolapWritebackMeasure(
             Member measure,
-            org.eclipse.daanse.rolap.mapping.model.Column column
+            org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column
     ) {
         super(column);
         this.measure = measure;

--- a/core/src/main/java/org/eclipse/daanse/rolap/core/internal/BasicContext.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/core/internal/BasicContext.java
@@ -96,7 +96,7 @@ public class BasicContext extends AbstractRolapContext implements RolapContext {
     @Reference(name = BASIC_CONTEXT_REF_NAME_CATALOG_MAPPING_SUPPLIER, target = UNRESOLVABLE_FILTER)
     private CatalogMappingSupplier catalogMappingSupplier;
 
-    private volatile org.eclipse.daanse.rolap.mapping.model.Catalog cachedCatalogMapping;
+    private volatile org.eclipse.daanse.rolap.mapping.model.catalog.Catalog cachedCatalogMapping;
 
     @Reference(name = BASIC_CONTEXT_REF_NAME_EXPRESSION_COMPILER_FACTORY)
     private ExpressionCompilerFactory expressionCompilerFactory;
@@ -193,7 +193,7 @@ public class BasicContext extends AbstractRolapContext implements RolapContext {
     }
 
     @Override
-    public org.eclipse.daanse.rolap.mapping.model.Catalog getCatalogMapping() {
+    public org.eclipse.daanse.rolap.mapping.model.catalog.Catalog getCatalogMapping() {
         if (cachedCatalogMapping == null) {
             cachedCatalogMapping = catalogMappingSupplier.get();
         }
@@ -243,9 +243,9 @@ public class BasicContext extends AbstractRolapContext implements RolapContext {
 
     @Override
     public List<String> getAccessRoles() {
-    	org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping = getCatalogMapping();
+    	org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping = getCatalogMapping();
         if (catalogMapping != null && catalogMapping.getAccessRoles() != null) {
-            return catalogMapping.getAccessRoles().stream().map(org.eclipse.daanse.rolap.mapping.model.AccessRole::getName).toList();
+            return catalogMapping.getAccessRoles().stream().map(org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole::getName).toList();
         }
         return List.of();// may take from mapping
     }

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapBaseCubeMeasure.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapBaseCubeMeasure.java
@@ -39,7 +39,7 @@ import org.eclipse.daanse.rolap.aggregator.DistinctCountAggregator;
 import org.eclipse.daanse.rolap.api.element.RolapMember;
 import org.eclipse.daanse.rolap.common.result.RolapResult;
 import org.eclipse.daanse.rolap.common.star.RolapSqlExpression;
-import org.eclipse.daanse.rolap.mapping.model.ColumnInternalDataType;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
 
 /**
  * Measure which is computed from a SQL column (or expression) and which is

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCatalog.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCatalog.java
@@ -111,7 +111,9 @@ import org.eclipse.daanse.rolap.common.member.SqlMemberSource;
 import org.eclipse.daanse.rolap.common.nativize.RolapNativeRegistry;
 import org.eclipse.daanse.rolap.common.star.RolapStar;
 import org.eclipse.daanse.rolap.common.star.RolapStarRegistry;
-import org.eclipse.daanse.rolap.mapping.model.ColumnInternalDataType;
+import org.eclipse.daanse.cwm.util.objectmodel.core.Namespaces;
+import org.eclipse.daanse.cwm.util.resource.relational.ColumnSets;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
 import org.eclipse.daanse.rolap.util.ClassResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -142,25 +144,25 @@ public class RolapCatalog implements Catalog {
 	/**
 	 * Holds cubes in this schema.
 	 */
-	private final Map<org.eclipse.daanse.rolap.mapping.model.Cube, RolapCube> mapMappingToRolapCube = new HashMap<>();
+	private final Map<org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube, RolapCube> mapMappingToRolapCube = new HashMap<>();
 
-	private final Map<org.eclipse.daanse.rolap.mapping.model.DatabaseSchema, RolapDatabaseSchema> mapMappingToRolapDatabaseSchema = new HashMap<>();
+	private final Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema, RolapDatabaseSchema> mapMappingToRolapDatabaseSchema = new HashMap<>();
 
-	private final Map<org.eclipse.daanse.rolap.mapping.model.Table, RolapDatabaseTable> mapMappingToRolapDatabaseTable = new HashMap<>();
+	private final Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet, RolapDatabaseTable> mapMappingToRolapDatabaseTable = new HashMap<>();
 
-	private final Map<org.eclipse.daanse.rolap.mapping.model.Column, RolapDatabaseColumn> mapMappingToRolapDatabaseColumn = new HashMap<>();
+	private final Map<org.eclipse.daanse.cwm.model.cwm.resource.relational.Column, RolapDatabaseColumn> mapMappingToRolapDatabaseColumn = new HashMap<>();
 
 	/**
 	 * Maps {@link String shared hierarchy name} to {@link MemberReader}. Shared
 	 * between all statements which use this connection.
 	 */
-	private final Map<org.eclipse.daanse.rolap.mapping.model.Dimension, MemberReader> mapSharedHierarchyToReader = new HashMap<>();
+	private final Map<org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension, MemberReader> mapSharedHierarchyToReader = new HashMap<>();
 
 	/**
 	 * Maps {@link String names of shared hierarchies} to {@link RolapHierarchy the
 	 * canonical instance of those hierarchies}.
 	 */
-	private final Map<org.eclipse.daanse.rolap.mapping.model.Dimension, RolapHierarchy> mapSharedHierarchyNameToHierarchy = new HashMap<>();
+	private final Map<org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension, RolapHierarchy> mapSharedHierarchyNameToHierarchy = new HashMap<>();
 
 	private List<RolapDatabaseSchema> rolapDbSchemas = new ArrayList<>();
 
@@ -185,14 +187,14 @@ public class RolapCatalog implements Catalog {
 	/**
 	 * Maps {@link AccessRoleMapping} to {@link Role roles }.
 	 */
-	private final Map<org.eclipse.daanse.rolap.mapping.model.AccessRole, Role> mapNameToRole = new HashMap<>();
+	private final Map<org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole, Role> mapNameToRole = new HashMap<>();
 
 	/**
 	 * Maps {@link String names of sets} to {@link NamedSet named sets}.
 	 */
 	private final Map<String, NamedSet> mapNameToSet = new HashMap<>();
 
-	private org.eclipse.daanse.rolap.mapping.model.Catalog mappingCatalog;
+	private org.eclipse.daanse.rolap.mapping.model.catalog.Catalog mappingCatalog;
 
 	public final List<RolapCatalogParameter> parameterList = new ArrayList<>();
 
@@ -384,7 +386,7 @@ public class RolapCatalog implements Catalog {
 		return parameterList;
 	}
 	
-	private void load(org.eclipse.daanse.rolap.mapping.model.Catalog mappingCatalog2) {
+	private void load(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog mappingCatalog2) {
 		this.name = mappingCatalog2.getName();
 		if (name == null || name.equals("")) {
 			throw Util.newError("<Schema> name must be set");
@@ -428,15 +430,15 @@ public class RolapCatalog implements Catalog {
 		}
 
 		// Create cubes.
-		for (org.eclipse.daanse.rolap.mapping.model.Cube cubeMapping : mappingCatalog2.getCubes()) {
+		for (org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cubeMapping : mappingCatalog2.getCubes()) {
 //            if (cubeMapping.isEnabled()) {
 			RolapCube cube = null;
-			if (cubeMapping instanceof org.eclipse.daanse.rolap.mapping.model.PhysicalCube physicalCubeMapping) {
+			if (cubeMapping instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube physicalCubeMapping) {
 				cube = new RolapPhysicalCube(this, mappingCatalog2, physicalCubeMapping, context);
 				// addCube(cubeMapping, cube);
 
 			}
-			if (cubeMapping instanceof org.eclipse.daanse.rolap.mapping.model.VirtualCube virtualCubeMapping) {
+			if (cubeMapping instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.VirtualCube virtualCubeMapping) {
 				cube = new RolapVirtualCube(this, mappingCatalog2, virtualCubeMapping, context);
 				// addCube(cubeMapping, cube);
 			}
@@ -454,27 +456,29 @@ public class RolapCatalog implements Catalog {
 //        }
 
 		// Create named sets.
-		for (org.eclipse.daanse.rolap.mapping.model.NamedSet namedSetsMapping : mappingCatalog2.getNamedSets()) {
+		for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet namedSetsMapping : mappingCatalog2.getNamedSets()) {
 			mapNameToSet.put(namedSetsMapping.getName(), createNamedSet(namedSetsMapping));
 		}
 
-	    for (org.eclipse.daanse.rolap.mapping.model.DatabaseSchema dbSchemaMapping : mappingCatalog2.getDbschemas()) {
+	    for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema dbSchemaMapping : mappingCatalog2.getDbschemas()) {
 	        RolapDatabaseSchema rolapDbSchema = new RolapDatabaseSchema();
 	        List<DatabaseTable> rolapDbTables = new ArrayList<>();
 	        rolapDbSchema.setName(rolapDbSchema.getName());
 
-	        for (org.eclipse.daanse.rolap.mapping.model.Table table : dbSchemaMapping.getTables()) {
+	        for (org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table : (Iterable<org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet>) Namespaces
+	                .ownedElementStream(dbSchemaMapping, org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet.class)::iterator) {
 	            RolapDatabaseTable rolapDbTable = new RolapDatabaseTable();
 	            List<DatabaseColumn> rolapDbColumns = new ArrayList<>();
 	            rolapDbTable.setName(table.getName());
 
-	            for (org.eclipse.daanse.rolap.mapping.model.Column column : table.getColumns()) {
+	            for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column : ColumnSets.columns(table)) {
 	                RolapDatabaseColumn rolapDbColumn = new RolapDatabaseColumn();
 	                rolapDbColumn.setName(column.getName());
-	                rolapDbColumn.setType(column.getType()!= null ? DataTypeJdbc.fromValue(column.getType().getLiteral()) : null );
-	                rolapDbColumn.setColumnSize(column.getColumnSize());
-	                rolapDbColumn.setNullable(column.getNullable());
-	                rolapDbColumn.setDecimalDigits(column.getDecimalDigits());
+	                rolapDbColumn.setType(column.getType() != null ? DataTypeJdbc.fromValue(column.getType().getName()) : null);
+	                org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _st = column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _s ? _s : null;
+	                rolapDbColumn.setColumnSize(_st != null ? (int) _st.getCharacterMaximumLength() : null);
+	                rolapDbColumn.setNullable(column.getIsNullable() != null ? (Boolean)(column.getIsNullable().getValue() == 1) : null);
+	                rolapDbColumn.setDecimalDigits(_st != null ? (int) _st.getNumericScale() : null);
 	                rolapDbColumns.add(rolapDbColumn);
 	                mapMappingToRolapDatabaseColumn.put(column, rolapDbColumn);
 	            }
@@ -488,7 +492,7 @@ public class RolapCatalog implements Catalog {
 	    }
 
 		// Create roles.
-		for (org.eclipse.daanse.rolap.mapping.model.AccessRole roleMapping : mappingCatalog2.getAccessRoles()) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole roleMapping : mappingCatalog2.getAccessRoles()) {
 			Role role = createRole(roleMapping);
 			mapNameToRole.put(roleMapping, role);
 		}
@@ -522,7 +526,7 @@ public class RolapCatalog implements Catalog {
 	 * language); }
 	 */
 
-	private NamedSet createNamedSet(org.eclipse.daanse.rolap.mapping.model.NamedSet namedSetsMapping) {
+	private NamedSet createNamedSet(org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet namedSetsMapping) {
 		final String formulaString = namedSetsMapping.getFormula();
 		final Expression exp;
 		try {
@@ -535,13 +539,13 @@ public class RolapCatalog implements Catalog {
 		return formula.getNamedSet();
 	}
 
-	private Role createRole(org.eclipse.daanse.rolap.mapping.model.AccessRole roleMapping) {
+	private Role createRole(org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole roleMapping) {
 		if (!roleMapping.getReferencedAccessRoles().isEmpty()) {
 			return createUnionRole(roleMapping);
 		}
 
 		RoleImpl role = new RoleImpl();
-		for (org.eclipse.daanse.rolap.mapping.model.AccessCatalogGrant catalogGrantMapings : roleMapping.getAccessCatalogGrants()) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.common.AccessCatalogGrant catalogGrantMapings : roleMapping.getAccessCatalogGrants()) {
 			handleCatalogGrant(role, catalogGrantMapings);
 		}
 		role.makeImmutable();
@@ -549,14 +553,14 @@ public class RolapCatalog implements Catalog {
 	}
 
 	// package-local visibility for testing purposes
-	public Role createUnionRole(org.eclipse.daanse.rolap.mapping.model.AccessRole roleMapping) {
+	public Role createUnionRole(org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole roleMapping) {
 		if (!roleMapping.getAccessCatalogGrants().isEmpty()) {
 			throw new RoleUnionGrantsException();
 		}
 
-		List<? extends org.eclipse.daanse.rolap.mapping.model.AccessRole> referencedRoleMappings = roleMapping.getReferencedAccessRoles();
+		List<? extends org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole> referencedRoleMappings = roleMapping.getReferencedAccessRoles();
 		List<Role> roleList = new ArrayList<>(referencedRoleMappings.size());
-		for (org.eclipse.daanse.rolap.mapping.model.AccessRole refRoleMapping : referencedRoleMappings) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole refRoleMapping : referencedRoleMappings) {
 			Role role = mapNameToRole.get(refRoleMapping);
 			if (role == null) {
 				throw new UnknownRoleException(refRoleMapping.getName());
@@ -567,41 +571,41 @@ public class RolapCatalog implements Catalog {
 	}
 
 	// package-local visibility for testing purposes
-	public void handleCatalogGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.AccessCatalogGrant schemaGrantMapings) {
+	public void handleCatalogGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.access.common.AccessCatalogGrant schemaGrantMapings) {
 		role.grant(this, getAccessCatalog(schemaGrantMapings.getCatalogAccess().getLiteral(), AccessCatalog.ALLOWED_SET));
-		for (org.eclipse.daanse.rolap.mapping.model.AccessCubeGrant cubeGrant : schemaGrantMapings.getCubeGrants()) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.olap.AccessCubeGrant cubeGrant : schemaGrantMapings.getCubeGrants()) {
 			handleCubeGrant(role, cubeGrant);
 		}
-		for (org.eclipse.daanse.rolap.mapping.model.AccessDatabaseSchemaGrant databaseSchemaGrant : schemaGrantMapings.getDatabaseSchemaGrants()) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.database.AccessDatabaseSchemaGrant databaseSchemaGrant : schemaGrantMapings.getDatabaseSchemaGrants()) {
 		    handleDatabaseSchemaGrant(role, databaseSchemaGrant);
 		}
 	}
 
-	public void handleDatabaseSchemaGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.AccessDatabaseSchemaGrant databaseSchemaGrant) {
+	public void handleDatabaseSchemaGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.access.database.AccessDatabaseSchemaGrant databaseSchemaGrant) {
         RolapDatabaseSchema databaseSchema = lookupDatabaseSchema(databaseSchemaGrant.getDatabaseSchema());
         if (databaseSchema == null) {
             throw Util.newError(
                     new StringBuilder("Unknown databaseSchema '").append(databaseSchemaGrant.getDatabaseSchema().getName()).append("'").toString());
         }
         role.grant(databaseSchema, getAccessDatabaseSchema(databaseSchemaGrant.getDatabaseSchemaAccess().name(), AccessDatabaseSchema.ALLOWED_SET));
-        for (org.eclipse.daanse.rolap.mapping.model.AccessTableGrant tableGrant : databaseSchemaGrant.getTableGrants()) {
+        for (org.eclipse.daanse.rolap.mapping.model.access.database.AccessTableGrant tableGrant : databaseSchemaGrant.getTableGrants()) {
             handleTableGrant(role, tableGrant);
         }
     }
 
-    private void handleTableGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.AccessTableGrant tableGrant) {
+    private void handleTableGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.access.database.AccessTableGrant tableGrant) {
         RolapDatabaseTable table = lookupTable(tableGrant.getTable());
         if (table == null) {
             throw Util.newError(
                     new StringBuilder("Unknown table '").append(tableGrant.getTable().getName()).append("'").toString());
         }
         role.grant(table, getAccessTable(tableGrant.getTableAccess().name(), AccessDatabaseTable.ALLOWED_SET));
-        for (org.eclipse.daanse.rolap.mapping.model.AccessColumnGrant columnGrant : tableGrant.getColumnGrants()) {
+        for (org.eclipse.daanse.rolap.mapping.model.access.database.AccessColumnGrant columnGrant : tableGrant.getColumnGrants()) {
             handleColumnGrant(role, columnGrant);
         }
     }
 
-    private void handleColumnGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.AccessColumnGrant columnGrant) {
+    private void handleColumnGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.access.database.AccessColumnGrant columnGrant) {
         RolapDatabaseColumn column = lookupColumn(columnGrant.getColumn());
         if (column == null) {
             throw Util.newError(
@@ -618,7 +622,7 @@ public class RolapCatalog implements Catalog {
         throw Util.newError(new StringBuilder("Bad value access='").append(accessString).append("'").toString());
     }
 
-    private RolapDatabaseColumn lookupColumn(org.eclipse.daanse.rolap.mapping.model.Column column) {
+    private RolapDatabaseColumn lookupColumn(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
         return mapMappingToRolapDatabaseColumn.get(column);
     }
 
@@ -630,7 +634,7 @@ public class RolapCatalog implements Catalog {
         throw Util.newError(new StringBuilder("Bad value access='").append(accessString).append("'").toString());
     }
 
-    private RolapDatabaseTable lookupTable(org.eclipse.daanse.rolap.mapping.model.Table table) {
+    private RolapDatabaseTable lookupTable(org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table) {
         return mapMappingToRolapDatabaseTable.get(table);
     }
 
@@ -642,12 +646,12 @@ public class RolapCatalog implements Catalog {
         throw Util.newError(new StringBuilder("Bad value access='").append(accessString).append("'").toString());
     }
 
-    private RolapDatabaseSchema lookupDatabaseSchema(org.eclipse.daanse.rolap.mapping.model.DatabaseSchema databaseSchema) {
+    private RolapDatabaseSchema lookupDatabaseSchema(org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema databaseSchema) {
         return mapMappingToRolapDatabaseSchema.get(databaseSchema);
     }
 
     // package-local visibility for testing purposes
-	public void handleCubeGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.AccessCubeGrant cubeGrant) {
+	public void handleCubeGrant(RoleImpl role, org.eclipse.daanse.rolap.mapping.model.access.olap.AccessCubeGrant cubeGrant) {
 		RolapCube cube = lookupCube(cubeGrant.getCube());
 		if (cube == null) {
 			throw Util.newError(
@@ -656,7 +660,7 @@ public class RolapCatalog implements Catalog {
 		role.grant(cube, getAccessCube(cubeGrant.getCubeAccess().name(), AccessCube.ALLOWED_SET));
 
 		CatalogReader reader = cube.getCatalogReader(null);
-		for (org.eclipse.daanse.rolap.mapping.model.AccessDimensionGrant accessDimGrantMapping : cubeGrant.getDimensionGrants()) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.olap.AccessDimensionGrant accessDimGrantMapping : cubeGrant.getDimensionGrants()) {
 			Dimension dimension;
 			if (accessDimGrantMapping.getDimension() != null) {
 				dimension = lookup(cube, reader, DataType.DIMENSION, accessDimGrantMapping.getDimension().getName());// not
@@ -672,14 +676,14 @@ public class RolapCatalog implements Catalog {
 			role.grant(dimension, getAccessDimension(accessDimGrantMapping.getDimensionAccess().name(), AccessDimension.ALLOWED_SET));
 		}
 
-		for (org.eclipse.daanse.rolap.mapping.model.AccessHierarchyGrant hierarchyGrant : cubeGrant.getHierarchyGrants()) {
+		for (org.eclipse.daanse.rolap.mapping.model.access.olap.AccessHierarchyGrant hierarchyGrant : cubeGrant.getHierarchyGrants()) {
 			handleHierarchyGrant(role, cube, reader, hierarchyGrant);
 		}
 	}
 
 	// package-local visibility for testing purposes
 	public void handleHierarchyGrant(RoleImpl role, RolapCube cube, CatalogReader reader,
-			org.eclipse.daanse.rolap.mapping.model.AccessHierarchyGrant hierarchyGrant) {
+			org.eclipse.daanse.rolap.mapping.model.access.olap.AccessHierarchyGrant hierarchyGrant) {
 		Hierarchy hierarchy;
 		if (hierarchyGrant.getHierarchy() != null) {
 			hierarchy = cube.lookupHierarchy(hierarchyGrant.getHierarchy());
@@ -717,7 +721,7 @@ public class RolapCatalog implements Catalog {
 				throw Util.newError("You may only specify <MemberGrant> if <Hierarchy> has access='custom'");
 			}
 
-			for (org.eclipse.daanse.rolap.mapping.model.AccessMemberGrant memberGrant : hierarchyGrant.getMemberGrants()) {
+			for (org.eclipse.daanse.rolap.mapping.model.access.olap.AccessMemberGrant memberGrant : hierarchyGrant.getMemberGrants()) {
 				Member member = reader.withLocus().getMemberByUniqueName(Util.parseIdentifier(memberGrant.getMember()),
 						!ignoreInvalidMembers);
 				if (member == null) {
@@ -753,7 +757,7 @@ public class RolapCatalog implements Catalog {
 	}
 
 	private Level findLevelForHierarchyGrant(RolapCube cube, CatalogReader schemaReader, AccessHierarchy hierarchyAccess,
-			org.eclipse.daanse.rolap.mapping.model.Level levelMapping, String desc) {
+			org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level levelMapping, String desc) {
 		if (levelMapping == null) {
 			return null;
 		}
@@ -810,7 +814,7 @@ public class RolapCatalog implements Catalog {
 	 * failIfNotFound controls whether to raise an error or return
 	 * null.
 	 */
-	public Cube lookupCube(final org.eclipse.daanse.rolap.mapping.model.Cube cube, final boolean failIfNotFound) {
+	public Cube lookupCube(final org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cube, final boolean failIfNotFound) {
 		RolapCube mdxCube = lookupCube(cube);
 		if (mdxCube == null && failIfNotFound) {
 			throw new OlapRuntimeException(MessageFormat.format("MDX cube ''{0}'' not found", cube));
@@ -822,7 +826,7 @@ public class RolapCatalog implements Catalog {
 	 * Finds a cube called 'cube' in the current catalog, or return null if no cube
 	 * exists.
 	 */
-	public RolapCube lookupCube(final org.eclipse.daanse.rolap.mapping.model.Cube cubeMapping) {
+	public RolapCube lookupCube(final org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cubeMapping) {
 		return mapMappingToRolapCube.get(cubeMapping);
 	}
 
@@ -838,12 +842,12 @@ public class RolapCatalog implements Catalog {
 	 * 'cubeName' or return null if no calculatedMember or xmlCube by those name
 	 * exists.
 	 */
-	public org.eclipse.daanse.rolap.mapping.model.CalculatedMember lookupMappingCalculatedMember(final String calcMemberName, final String cubeName) {
-		for (final org.eclipse.daanse.rolap.mapping.model.Cube cube : mappingCatalog.getCubes()) {
+	public org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember lookupMappingCalculatedMember(final String calcMemberName, final String cubeName) {
+		for (final org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cube : mappingCatalog.getCubes()) {
 			if (!Util.equalName(cube.getName(), cubeName)) {
 				continue;
 			}
-			for (org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember : cube.getCalculatedMembers()) {
+			for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember : cube.getCalculatedMembers()) {
 				// FIXME: Since fully-qualified names are not unique, we
 				// should compare unique names. Also, the logic assumes that
 				// CalculatedMember.dimension is not quoted (e.g. "Time")
@@ -859,7 +863,7 @@ public class RolapCatalog implements Catalog {
 		return null;
 	}
 
-	public static String calcMemberFqName(org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember) {
+	public static String calcMemberFqName(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember) {
 		if (mappingCalcMember.getHierarchy() != null) {
 			return Util.makeFqName(mappingCalcMember.getHierarchy().getName(), mappingCalcMember.getName());
 		}
@@ -882,7 +886,7 @@ public class RolapCatalog implements Catalog {
 	 * @param cubeMapping
 	 * @see #lookupCube(String)
 	 */
-	protected void addCube(org.eclipse.daanse.rolap.mapping.model.Cube cubeMapping, final RolapCube cube) {
+	protected void addCube(org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cubeMapping, final RolapCube cube) {
 		mapMappingToRolapCube.put(cubeMapping, cube);
 	}
 
@@ -896,7 +900,7 @@ public class RolapCatalog implements Catalog {
 		return new ArrayList<>(mapMappingToRolapCube.values());
 	}
 
-	RolapHierarchy getSharedHierarchy(final org.eclipse.daanse.rolap.mapping.model.Dimension name) {
+	RolapHierarchy getSharedHierarchy(final org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension name) {
 		return mapSharedHierarchyNameToHierarchy.get(name);
 	}
 
@@ -917,7 +921,7 @@ public class RolapCatalog implements Catalog {
 		return null;
 	}
 
-	public Role lookupRole(final org.eclipse.daanse.rolap.mapping.model.AccessRole accessRoleMapping) {
+	public Role lookupRole(final org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole accessRoleMapping) {
 		return mapNameToRole.get(accessRoleMapping);
 	}
 
@@ -930,7 +934,7 @@ public class RolapCatalog implements Catalog {
 	}
 
 	public Set<String> roleNames() {
-		return mapNameToRole.keySet().stream().map(org.eclipse.daanse.rolap.mapping.model.AccessRole::getName).collect(Collectors.toSet());
+		return mapNameToRole.keySet().stream().map(org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole::getName).collect(Collectors.toSet());
 	}
 
 	@Override
@@ -946,7 +950,7 @@ public class RolapCatalog implements Catalog {
 	 *
 	 * Synchronization: thread safe
 	 */
-	synchronized MemberReader createMemberReader(final org.eclipse.daanse.rolap.mapping.model.Dimension xmlDimension, final RolapHierarchy hierarchy,
+	synchronized MemberReader createMemberReader(final org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension xmlDimension, final RolapHierarchy hierarchy,
 			final String memberReaderClass) {
 		MemberReader reader;
 		if (xmlDimension != null) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapColumn.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapColumn.java
@@ -77,12 +77,12 @@ public class RolapColumn extends RolapSqlExpression {
         if (!(obj instanceof RolapColumn that)) {
             return false;
         }
-        return getName().equals(that.getName()) &&
+        return Objects.equals(getName(), that.getName()) &&
             Objects.equals(getTable(), that.getTable());
     }
 
     @Override
 	public int hashCode() {
-        return getName().hashCode() ^ (getTable()==null ? 0 : getTable().hashCode());
+        return (getName() == null ? 0 : getName().hashCode()) ^ (getTable()==null ? 0 : getTable().hashCode());
     }
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCube.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCube.java
@@ -131,10 +131,11 @@ import org.eclipse.daanse.rolap.common.util.PojoUtil;
 import org.eclipse.daanse.rolap.common.writeback.RolapWritebackTable;
 import org.eclipse.daanse.rolap.common.writeback.WritebackUtil;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
-import org.eclipse.daanse.rolap.mapping.model.SqlStatement;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 /**
  * RolapCube implements {@link Cube} for a ROLAP database.
  *
@@ -167,10 +168,10 @@ public abstract class RolapCube extends CubeBase {
     private final MetaData metaData;
     private final RolapHierarchy measuresHierarchy;
 
-    private org.eclipse.daanse.rolap.mapping.model.RelationalQuery restoreFact = null;
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource restoreFact = null;
 
     /** For SQL generator. Fact table. */
-    private org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact;
+    private org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact;
 
     /** Schema reader which can see this cube and nothing else. */
     private CatalogReader schemaReader;
@@ -227,10 +228,10 @@ public abstract class RolapCube extends CubeBase {
 
     protected RolapCube(
             RolapCatalog catalog,
-            org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping,
-            org.eclipse.daanse.rolap.mapping.model.PhysicalCube cubeMapping,
+            org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping,
+            org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube cubeMapping,
             boolean isCache,
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact,
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact,
             Context context)
         {
         this(
@@ -252,10 +253,10 @@ public abstract class RolapCube extends CubeBase {
 
     protected RolapCube(
             RolapCatalog catalog,
-            org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping,
-            org.eclipse.daanse.rolap.mapping.model.VirtualCube cubeMapping,
+            org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping,
+            org.eclipse.daanse.rolap.mapping.model.olap.cube.VirtualCube cubeMapping,
             boolean isCache,
-            org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact,
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact,
             Context context)
         {
         this(
@@ -287,14 +288,14 @@ public abstract class RolapCube extends CubeBase {
      */
     private RolapCube(
         RolapCatalog catalog,
-        org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping,
+        org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping,
         String name,
         boolean visible,
         String caption,
         String description,
         boolean isCache,
-        org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact,
-        List<? extends org.eclipse.daanse.rolap.mapping.model.DimensionConnector> dimensions,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact,
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector> dimensions,
         MetaData metaData,
         Context context)
     {
@@ -345,7 +346,7 @@ public abstract class RolapCube extends CubeBase {
         }
 
         for (int i = 0; i < dimensions.size(); i++) {
-        	org.eclipse.daanse.rolap.mapping.model.DimensionConnector mappingCubeDimension = dimensions.get(i);
+        	org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector mappingCubeDimension = dimensions.get(i);
 
             // Look up usages of shared dimensions in the schema before
             // consulting the XML schema (which may be null).
@@ -387,11 +388,11 @@ public abstract class RolapCube extends CubeBase {
     /**
      * Returns this cube's fact table, null if the cube is virtual.
      */
-    public org.eclipse.daanse.rolap.mapping.model.RelationalQuery getFact() {
+    public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getFact() {
         return fact;
     }
 
-    public void setFact(org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact) {
+    public void setFact(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact) {
         this.fact = fact;
     }
 
@@ -423,7 +424,7 @@ public abstract class RolapCube extends CubeBase {
 		return closureColumnBitKey;
 	}
     
-    private void fillKpiIfExist(org.eclipse.daanse.rolap.mapping.model.Cube cube) {
+    private void fillKpiIfExist(org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cube) {
         if (cube != null && cube.getKpis() != null) {
             cube.getKpis().stream().forEach(kpiMapping -> {
                 RolapKPI kpi = new RolapKPI();
@@ -485,7 +486,7 @@ public abstract class RolapCube extends CubeBase {
         return aggGroup;
     }
 
-    void loadAggGroup(org.eclipse.daanse.rolap.mapping.model.PhysicalCube mappingCube) {
+    void loadAggGroup(org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube mappingCube) {
         aggGroup = ExplicitRules.Group.make(this, mappingCube);
     }
 
@@ -502,9 +503,9 @@ public abstract class RolapCube extends CubeBase {
      * @return A dimension
      */
     private RolapCubeDimension getOrCreateDimension(
-    		org.eclipse.daanse.rolap.mapping.model.DimensionConnector mappingCubeDimension,
+    		org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector mappingCubeDimension,
         RolapCatalog schema,
-        org.eclipse.daanse.rolap.mapping.model.Catalog mappingSchema,
+        org.eclipse.daanse.rolap.mapping.model.catalog.Catalog mappingSchema,
         int dimensionOrdinal,
         List<RolapHierarchy> cubeHierarchyList)
     {
@@ -518,7 +519,7 @@ public abstract class RolapCube extends CubeBase {
 
 
         if (dimension == null) {
-        	org.eclipse.daanse.rolap.mapping.model.Dimension mappingDimension = mappingCubeDimension.getDimension();
+        	org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension mappingDimension = mappingCubeDimension.getDimension();
             if (mappingDimension == null) {
             	if (mappingCubeDimension.getPhysicalCube() != null) { //for virtual cube
             		mappingDimension = DimensionUtil.getDimension(mappingCubeDimension.getPhysicalCube(), mappingSchema, mappingCubeDimension.getOverrideDimensionName());
@@ -548,8 +549,8 @@ public abstract class RolapCube extends CubeBase {
      * @param errOnDups throws an error if a duplicate member is found
      */
     public void createCalcMembersAndNamedSets(
-    	List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> list,
-        List<? extends org.eclipse.daanse.rolap.mapping.model.NamedSet> mappingNamedSets,
+    	List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> list,
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet> mappingNamedSets,
         List<RolapMember> memberList,
         RolapCube cube,
         boolean errOnDups)
@@ -578,8 +579,8 @@ public abstract class RolapCube extends CubeBase {
     }
 
     protected Query resolveCalcMembers(
-    	List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> list,
-        List<? extends org.eclipse.daanse.rolap.mapping.model.NamedSet> mappingNamedSets,
+    	List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> list,
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet> mappingNamedSets,
         RolapCube cube,
         boolean errOnDups)
     {
@@ -603,7 +604,7 @@ public abstract class RolapCube extends CubeBase {
         for (Formula namedSet : namedSetList) {
             nameSet.add(namedSet.getName());
         }
-        for (org.eclipse.daanse.rolap.mapping.model.NamedSet mappingNamedSet : mappingNamedSets) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet mappingNamedSet : mappingNamedSets) {
             preNamedSet(mappingNamedSet, nameSet, buf);
         }
 
@@ -627,12 +628,12 @@ public abstract class RolapCube extends CubeBase {
     }
 
     private void postNamedSet(
-        List<? extends org.eclipse.daanse.rolap.mapping.model.NamedSet> mappingNamedSets,
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet> mappingNamedSets,
         final int offset,
         int i,
         final Query queryExp)
     {
-    	org.eclipse.daanse.rolap.mapping.model.NamedSet mappingNamedSet = mappingNamedSets.get(i);
+    	org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet mappingNamedSet = mappingNamedSets.get(i);
 //        discard(xmlNamedSet);
         Formula formula = queryExp.getFormulas()[offset + i];
         final SetBase namedSet = (SetBase) formula.getNamedSet();
@@ -661,7 +662,7 @@ public abstract class RolapCube extends CubeBase {
     }
 
     private void preNamedSet(
-    		org.eclipse.daanse.rolap.mapping.model.NamedSet mappingNamedSet,
+    		org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet mappingNamedSet,
         Set<String> nameSet,
         StringBuilder buf)
     {
@@ -679,12 +680,12 @@ public abstract class RolapCube extends CubeBase {
     }
 
     private void postCalcMember(
-        List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> mappingCalcMembers,
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> mappingCalcMembers,
         int i,
         final Query queryExp,
         List<RolapMember> memberList)
     {
-    	org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember = mappingCalcMembers.get(i);
+    	org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember = mappingCalcMembers.get(i);
 
         final Formula formula = queryExp.getFormulas()[i];
 
@@ -729,14 +730,14 @@ public abstract class RolapCube extends CubeBase {
     }
 
     private void preCalcMember(
-    	List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> list,
+    	List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> list,
         int j,
         StringBuilder buf,
         RolapCube cube,
         boolean errOnDup,
         Set<String> fqNames)
     {
-    	org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember = list.get(j);
+    	org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember = list.get(j);
 
         // Lookup dimension
         Hierarchy hierarchy = null;
@@ -745,7 +746,7 @@ public abstract class RolapCube extends CubeBase {
             hierarchy = measuresHierarchy;
         } else {
             // with new mapping
-        	org.eclipse.daanse.rolap.mapping.model.Hierarchy hierarchyMappingOfCalcMember = mappingCalcMember.getHierarchy();
+        	org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy hierarchyMappingOfCalcMember = mappingCalcMember.getHierarchy();
             hierarchy = hierarchyList.stream(
                     ).filter(h -> hierarchyMappingOfCalcMember.equals(h.hierarchyMapping))
                     .findAny().orElse(null);
@@ -826,7 +827,7 @@ public abstract class RolapCube extends CubeBase {
             throw new CalcMemberNotUniqueException(fqName, getName());
         }
 
-        final List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMemberProperty> mappingProperties =
+        final List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMemberProperty> mappingProperties =
                 mappingCalcMember.getCalculatedMemberProperties();
         List<String> propNames = new ArrayList<>();
         List<String> propExprs = new ArrayList<>();
@@ -913,7 +914,7 @@ public abstract class RolapCube extends CubeBase {
     }
 
     public void processFormatStringAttribute(
-    		org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember,
+    		org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember,
         StringBuilder buf)
     {
         if (getFormatString(mappingCalcMember) != null) {
@@ -935,7 +936,7 @@ public abstract class RolapCube extends CubeBase {
      * @param memberName Name of member which the properties belong to.
      */
     protected void validateMemberProps(
-        final List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMemberProperty> list,
+        final List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMemberProperty> list,
         List<String> propNames,
         List<String> propExprs,
         String memberName)
@@ -943,7 +944,7 @@ public abstract class RolapCube extends CubeBase {
         if (list == null) {
             return;
         }
-        for (org.eclipse.daanse.rolap.mapping.model.CalculatedMemberProperty mappingProperty : list) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMemberProperty mappingProperty : list) {
             if (mappingProperty.getExpression() == null && mappingProperty.getValue() == null) {
                 throw  new OlapRuntimeException(MessageFormat.format(
                     neitherExprNorValueForCalcMemberProperty,
@@ -1004,11 +1005,11 @@ public abstract class RolapCube extends CubeBase {
         }
     }
 
-    private org.eclipse.daanse.rolap.mapping.model.DimensionConnector lookup(
-        List<? extends org.eclipse.daanse.rolap.mapping.model.DimensionConnector> mappingDimensions,
+    private org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector lookup(
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector> mappingDimensions,
         String name)
     {
-        for (org.eclipse.daanse.rolap.mapping.model.DimensionConnector cd : mappingDimensions) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cd : mappingDimensions) {
             if (name.equals(cd.getOverrideDimensionName())) {
                 return cd;
             }
@@ -1017,7 +1018,7 @@ public abstract class RolapCube extends CubeBase {
         return null;
     }
 
-    protected void init(List<? extends org.eclipse.daanse.rolap.mapping.model.DimensionConnector> mappingDimensions) {
+    protected void init(List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector> mappingDimensions) {
         for (Dimension dimension1 : dimensions) {
             final RolapDimension dimension = (RolapDimension) dimension1;
             dimension.init(lookup(mappingDimensions, dimension.getName()));
@@ -1099,20 +1100,30 @@ public abstract class RolapCube extends CubeBase {
 
     /**
      * Returns this cube's underlying star schema.
+     *
+     * <p>Virtual cubes (no fact) return {@code null}. For any cube with a fact,
+     * the cached {@code star} is returned when its fact table relation still
+     * matches {@link #getFact()}; otherwise a fresh {@link RolapStar} is
+     * created from the current fact. This makes the method resilient to
+     * post-construction {@code fact} mutations (see {@link #modifyFact}
+     * / {@link #restoreFact}) and to cross-test state pollution where a
+     * cube's {@code fact} has been re-bound between calls.
      */
     public RolapStar getStar() {
-        if (this instanceof RolapPhysicalCube ) {
-            if (star != null && star.getFactTable().getRelation().equals(getFact())) {
-                return star;
-            }
-            star = catalog.getRolapStarRegistry().makeRolapStar(getFact());
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact = getFact();
+        if (fact == null) {
+            return star;
         }
+        if (star != null && star.getFactTable().getRelation().equals(fact)) {
+            return star;
+        }
+        star = catalog.getRolapStarRegistry().makeRolapStar(fact);
         return star;
     }
 
     private void createUsages(
         RolapCubeDimension dimension,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector mappingCubeDimension)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector mappingCubeDimension)
     {
         // RME level may not be in all hierarchies
         // If one uses the DimensionUsage attribute "level", which level
@@ -1165,7 +1176,7 @@ public abstract class RolapCube extends CubeBase {
 
     synchronized void createUsage(
         RolapCubeHierarchy hierarchy,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim)
     {
         HierarchyUsage usage = new HierarchyUsage(this, hierarchy, cubeDim);
         if (LOGGER.isDebugEnabled()) {
@@ -1340,7 +1351,7 @@ public abstract class RolapCube extends CubeBase {
         for (Hierarchy hierarchy1 : hierarchies) {
             RolapHierarchy hierarchy = (RolapHierarchy) hierarchy1;
 
-            org.eclipse.daanse.rolap.mapping.model.Query relation = hierarchy.getRelation();
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = hierarchy.getRelation();
             if (relation == null) {
                 continue; // e.g. [Measures] hierarchy
             }
@@ -1383,10 +1394,10 @@ public abstract class RolapCube extends CubeBase {
                 // a Join, i.e., the dimension is not a snowflake,
                 // there is a single dimension table, then this is currently
                 // an unsupported configuation and all bets are off.
-                if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery) {
+                if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) {
                     // RME
                     // take out after things seem to be working
-                	org.eclipse.daanse.rolap.mapping.model.Query relationTmp1 = relation;
+                	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationTmp1 = relation;
 
                     relation = reorder(relation, levels);
 
@@ -1399,7 +1410,7 @@ public abstract class RolapCube extends CubeBase {
                     }
                 }
 
-                org.eclipse.daanse.rolap.mapping.model.Query relationTmp2 = relation;
+                org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationTmp2 = relation;
 
                 if (levelName != null) {
                     // When relation is a table, this does nothing. Otherwise
@@ -1429,7 +1440,7 @@ public abstract class RolapCube extends CubeBase {
                     // If the child level is null, then the DimensionUsage
                     // level attribute was simply set to the default, lowest
                     // level and we do nothing.
-                    if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery) {
+                    if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) {
                         RolapLevel childLevel =
                             (RolapLevel) level.getChildLevel();
                         if (childLevel != null) {
@@ -1476,19 +1487,15 @@ public abstract class RolapCube extends CubeBase {
 
                     if (hierarchy.getHierarchyMapping() != null
                             && hierarchy.getHierarchyMapping().getPrimaryKey() != null
-                            && hierarchy.getHierarchyMapping().getPrimaryKey()
-                            .getTable() != null
-                            && relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join
-                            && right(join) instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery tqm
+                            && hierarchy.getHierarchyMapping().getPrimaryKey().getOwner() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.Table _pkTbl
+                            && relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join
+                            && right(join) instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource tqm
                             && getAlias(tqm) != null
-                            && getAlias(tqm)
-                            .equals(
-                                hierarchy.getHierarchyMapping().getPrimaryKey()
-                              .getTable().getName()))
+                            && getAlias(tqm).equals(_pkTbl.getName()))
                     {
-                        org.eclipse.daanse.rolap.mapping.model.JoinQuery newRelation = RolapMappingFactory.eINSTANCE.createJoinQuery();
-                        org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement leftElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
-                        org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement rightElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+                        org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource newRelation = SourceFactory.eINSTANCE.createJoinSource();
+                        org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement leftElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
+                        org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement rightElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
                         
                         leftElement.setAlias(getRightAlias(join));
                         leftElement.setKey(join.getRight().getKey());
@@ -1609,18 +1616,18 @@ public abstract class RolapCube extends CubeBase {
      *
      * @param relation A table or a join
      */
-    private static String format(org.eclipse.daanse.rolap.mapping.model.Query relation) {
+    private static String format(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
         StringBuilder buf = new StringBuilder();
         format(relation, buf, "");
         return buf.toString();
     }
 
     private static void format(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         StringBuilder buf,
         String indent)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
             buf.append(indent);
             buf.append(table.getTable().getName());
             if (table.getAlias() != null) {
@@ -1630,7 +1637,7 @@ public abstract class RolapCube extends CubeBase {
             }
             buf.append(Util.NL);
         } else {
-        	org.eclipse.daanse.rolap.mapping.model.JoinQuery join = (org.eclipse.daanse.rolap.mapping.model.JoinQuery) relation;
+        	org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join = (org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) relation;
             String subindent = new StringBuilder(indent).append("  ").toString();
 
             buf.append(indent);
@@ -1774,8 +1781,8 @@ public abstract class RolapCube extends CubeBase {
      * @param relation A table or a join
      * @param levels Levels in hierarchy
      */
-    private static org.eclipse.daanse.rolap.mapping.model.Query reorder(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource reorder(
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         List<RolapCubeLevel> levels)
     {
         // Need at least two levels, with only one level theres nothing to do.
@@ -1805,7 +1812,7 @@ public abstract class RolapCube extends CubeBase {
         if (! validateNodes(relation, nodeMap)) {
             return relation;
         }
-        org.eclipse.daanse.rolap.mapping.model.Query relationImpl = copy(relation);
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationImpl = copy(relation);
 
         // Put lower levels to the left of upper levels
         leftToRight(relationImpl, nodeMap);
@@ -1825,14 +1832,14 @@ public abstract class RolapCube extends CubeBase {
      * @param map Names of tables and {@link RelNode} pairs
      */
     private static boolean validateNodes(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         Map<String, RelNode> map)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery table) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table) {
             RelNode relNode = RelNode.lookup(table, map);
             return (relNode != null);
 
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
             return validateNodes(left(join), map)
                 && validateNodes(right(join), map);
 
@@ -1850,10 +1857,10 @@ public abstract class RolapCube extends CubeBase {
      * @param map Names of tables and {@link RelNode} pairs
      */
     private static int leftToRight(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         Map<String, RelNode> map)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery table) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table) {
             RelNode relNode = RelNode.lookup(table, map);
             // Associate the table with its RelNode!!!! This is where this
             // happens.
@@ -1861,17 +1868,17 @@ public abstract class RolapCube extends CubeBase {
 
             return relNode.getDepth();
 
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
-            int leftDepth = leftToRight((org.eclipse.daanse.rolap.mapping.model.Query)left(join), map);
-            int rightDepth = leftToRight((org.eclipse.daanse.rolap.mapping.model.Query)right(join), map);
+        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+            int leftDepth = leftToRight((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource)left(join), map);
+            int rightDepth = leftToRight((org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource)right(join), map);
 
             // we want the right side to be less than the left
             if (rightDepth > leftDepth) {
                 // switch
                 String leftAlias = getLeftAlias(join);
-                org.eclipse.daanse.rolap.mapping.model.Column leftKey = join.getLeft().getKey();
-                org.eclipse.daanse.rolap.mapping.model.Query left = copy(left(join));
-                org.eclipse.daanse.rolap.mapping.model.Query right = copy(right(join));
+                org.eclipse.daanse.cwm.model.cwm.resource.relational.Column leftKey = join.getLeft().getKey();
+                org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left = copy(left(join));
+                org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right = copy(right(join));
                 join.getLeft().setAlias(getRightAlias(join));
                 join.getLeft().setKey(join.getRight().getKey());
                 changeLeftRight(join, right, left);
@@ -1896,21 +1903,21 @@ public abstract class RolapCube extends CubeBase {
      *
      * @param relation A table or a join
      */
-    private static void topToBottom(org.eclipse.daanse.rolap.mapping.model.Query relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery) {
+    private static void topToBottom(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource) {
             // nothing
 
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
-            while (left(join) instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery leftJoin) {
-                org.eclipse.daanse.rolap.mapping.model.JoinQuery jleft = leftJoin;
-                org.eclipse.daanse.rolap.mapping.model.JoinQuery joinQuery = RolapMappingFactory.eINSTANCE.createJoinQuery();
+        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+            while (left(join) instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource leftJoin) {
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource jleft = leftJoin;
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource joinQuery = SourceFactory.eINSTANCE.createJoinSource();
 
-                org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement leftElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement leftElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
                 leftElement.setAlias(getLeftAlias(join));
                 leftElement.setKey(join.getLeft().getKey());
                 leftElement.setQuery(PojoUtil.copy(right(jleft)));
 
-                org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement rightElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement rightElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
                 rightElement.setAlias(getRightAlias(join));
                 rightElement.setKey(join.getRight().getKey());
                 rightElement.setQuery(PojoUtil.copy(right(join)));
@@ -1919,12 +1926,12 @@ public abstract class RolapCube extends CubeBase {
                 joinQuery.setRight(rightElement);
                 
                 changeLeftRight(join, copy(left(jleft)), joinQuery);
-                org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement right = join.getRight();
-                org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement left = join.getLeft();
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement right = join.getRight();
+                org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement left = join.getLeft();
                 right.setAlias(getRightAlias(jleft));
-                right.setKey((org.eclipse.daanse.rolap.mapping.model.PhysicalColumn) jleft.getRight().getKey());
+                right.setKey((org.eclipse.daanse.cwm.model.cwm.resource.relational.Column) jleft.getRight().getKey());
                 left.setAlias(getLeftAlias(jleft));
-                left.setKey((org.eclipse.daanse.rolap.mapping.model.PhysicalColumn) jleft.getLeft().getKey());
+                left.setKey((org.eclipse.daanse.cwm.model.cwm.resource.relational.Column) jleft.getLeft().getKey());
             }
         }
     }
@@ -1939,11 +1946,11 @@ public abstract class RolapCube extends CubeBase {
      * @param relation A table or a join
      * @param tableName Table name in relation
      */
-    private static org.eclipse.daanse.rolap.mapping.model.Query snip(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource snip(
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         String tableName)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
             // Return null if the table's name or alias matches tableName
             if ((table.getAlias() != null) && table.getAlias().equals(tableName)) {
                 return null;
@@ -1951,9 +1958,9 @@ public abstract class RolapCube extends CubeBase {
                 return table.getTable().getName().equals(tableName) ? null : table;
             }
 
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
+        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
             // snip left
-        	org.eclipse.daanse.rolap.mapping.model.Query left = snip(left(join), tableName);
+        	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource left = snip(left(join), tableName);
             if (left == null) {
                 // left got snipped so return the right
                 // (the join is no longer a join).
@@ -1961,10 +1968,10 @@ public abstract class RolapCube extends CubeBase {
 
             } else {
                 // whatever happened on the left, save it
-                changeLeftRight((org.eclipse.daanse.rolap.mapping.model.JoinQuery)copy(join), copy(left), copy(right(join)));
+                changeLeftRight((org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource)copy(join), copy(left), copy(right(join)));
 
                 // snip right
-                org.eclipse.daanse.rolap.mapping.model.Query right = snip(right(join), tableName);
+                org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource right = snip(right(join), tableName);
                 if (right == null) {
                     // right got snipped so return the left.
                     return left(join);
@@ -1972,7 +1979,7 @@ public abstract class RolapCube extends CubeBase {
                 } else {
                     // save the right, join still has right and left children
                     // so return it.
-                    changeLeftRight((org.eclipse.daanse.rolap.mapping.model.JoinQuery)copy(join), copy(left(join)), copy(right));
+                    changeLeftRight((org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource)copy(join), copy(left(join)), copy(right));
                     return join;
                 }
             }
@@ -2473,13 +2480,13 @@ public abstract class RolapCube extends CubeBase {
         this.writebackTable = writebackTable;
     }
 
-	public Hierarchy lookupHierarchy(org.eclipse.daanse.rolap.mapping.model.Hierarchy hierarchy) {
+	public Hierarchy lookupHierarchy(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy hierarchy) {
         return hierarchyList.stream(
                 ).filter(h -> hierarchy.equals(h.hierarchyMapping))
                 .findAny().orElse(null);
 	}
 
-	public Level lookupLevel(org.eclipse.daanse.rolap.mapping.model.Level level, Hierarchy h) {
+	public Level lookupLevel(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level, Hierarchy h) {
 		if (level != null && h != null && h.getLevels() != null) {
 			for (Level l : h.getLevels()) {
 				if (l instanceof RolapLevel rl) {
@@ -2499,7 +2506,7 @@ public abstract class RolapCube extends CubeBase {
 
 	@Override
     public void modifyFact(List<Map<String, Entry<DataTypeJdbc, Object>>> sessionValues) {
-		org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact = getFact();
+		org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact = getFact();
             restoreFact = fact;
             Optional<RolapWritebackTable> oWritebackTable = getWritebackTable();
             Dialect dialect = getContext().getDialect();
@@ -2507,61 +2514,59 @@ public abstract class RolapCube extends CubeBase {
                 RolapWritebackTable writebackTable = oWritebackTable.get();
                 if (getWritebackTable() != null && getWritebackTable().isPresent()) {
                     List<Map<String, Entry<Datatype, Object>>> rolapSessionValues = EnumConvertor.convertSessionValues(sessionValues);
-                    if (fact instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mappingTable) {
+                    if (fact instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mappingTable) {
                         String alias = mappingTable.getAlias() != null ? mappingTable.getAlias() : mappingTable.getTable().getName();
                         StringBuilder sql = new StringBuilder("select ").append(writebackTable.getColumns().stream().map( c -> c.getColumn().getName() )
                         .collect(Collectors.joining(", "))).append(" from ").append(mappingTable.getTable().getName());
                         sql.append(getWriteBackSql(dialect, writebackTable, rolapSessionValues));
-                        org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+                        org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
                         sqlStatement.setSql(sql.toString());
                         sqlStatement.getDialects().add("generic");
                         sqlStatement.getDialects().add(dialect.getDialectName());
                         
-                        org.eclipse.daanse.rolap.mapping.model.DatabaseSchema schema = RolapMappingFactory.eINSTANCE.createDatabaseSchema();
-                        schema.setName(mappingTable.getTable().getSchema().getName());
-                        org.eclipse.daanse.rolap.mapping.model.SqlView sqlView = RolapMappingFactory.eINSTANCE.createSqlView();
-                        sqlView.getSqlStatements().add(sqlStatement);
-                        sqlView.setSchema(schema);
-                        org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery sqlSelectQuery = RolapMappingFactory.eINSTANCE.createSqlSelectQuery();
+                        org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema schema = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createSchema();
+                        schema.setName(mappingTable.getTable().getNamespace().getName());
+                        org.eclipse.daanse.rolap.mapping.model.database.relational.DialectSqlView sqlView = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createDialectSqlView();
+                        sqlView.getDialectStatements().add(sqlStatement);
+                        org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource sqlSelectQuery = SourceFactory.eINSTANCE.createSqlSelectSource();
                         sqlSelectQuery.setSql(sqlView);
                         sqlSelectQuery.setAlias(alias);
                         changeFact(sqlSelectQuery);
                     }
-                    if (fact instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery mappingInlineTable) {
+                    if (fact instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource mappingInlineTable) {
                     	List<String> columns =  writebackTable.getColumns().stream().map(c -> c.getColumn().getName()).toList();
-                    	org.eclipse.daanse.rolap.mapping.model.RelationalQuery mappingRelation = RolapUtil.convertInlineTableToRelation(mappingInlineTable, getContext().getDialect(), columns);
-                        if (mappingRelation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery mappingView) {
+                    	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource mappingRelation = RolapUtil.convertInlineTableToRelation(mappingInlineTable, getContext().getDialect(), columns);
+                        if (mappingRelation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource mappingView) {
                             changeFact(mappingView, dialect, writebackTable, rolapSessionValues);
                         }
                     }
-                    if (fact instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery mappingView) {
+                    if (fact instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource mappingView) {
                         changeFact(mappingView, dialect, writebackTable, rolapSessionValues);
                     }
                 }
             }
     }
 
-    private void changeFact(org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery mappingView, Dialect dialect, RolapWritebackTable writebackTable, List<Map<String, Map.Entry<Datatype, Object>>> sessionValues) {
-        if (mappingView.getSql() != null && mappingView.getSql().getSqlStatements() != null) {
-            List<? extends org.eclipse.daanse.rolap.mapping.model.SqlStatement> statements = mappingView.getSql().getSqlStatements().stream()
+    private void changeFact(org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource mappingView, Dialect dialect, RolapWritebackTable writebackTable, List<Map<String, Map.Entry<Datatype, Object>>> sessionValues) {
+        if (mappingView.getSql() != null && mappingView.getSql().getDialectStatements() != null) {
+            List<? extends org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement> statements = mappingView.getSql().getDialectStatements().stream()
                 .map(sql -> {
-                    SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+                    SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
                     sqlStatement.setSql(new StringBuilder(sql.getSql()).append(getWriteBackSql(dialect, writebackTable, sessionValues)).toString());
                     sqlStatement.getDialects().addAll(sql.getDialects());
                     return sqlStatement;
                 })
                 .toList();
-            org.eclipse.daanse.rolap.mapping.model.SqlView sqlView = RolapMappingFactory.eINSTANCE.createSqlView();
-            sqlView.getSqlStatements().addAll(statements);
-            sqlView.setSchema(mappingView.getSql().getSchema());
-            org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery sqlSelectQuery = RolapMappingFactory.eINSTANCE.createSqlSelectQuery();
+            org.eclipse.daanse.rolap.mapping.model.database.relational.DialectSqlView sqlView = org.eclipse.daanse.rolap.mapping.model.database.relational.RelationalFactory.eINSTANCE.createDialectSqlView();
+            sqlView.getDialectStatements().addAll(statements);
+            org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource sqlSelectQuery = SourceFactory.eINSTANCE.createSqlSelectSource();
             sqlSelectQuery.setSql(sqlView);
             sqlSelectQuery.setAlias(mappingView.getAlias());
             changeFact(sqlSelectQuery);
         }
     }
 
-    private void changeFact(org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery sqls) {
+    private void changeFact(org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource sqls) {
         setFact(sqls);
         register();
     }

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCubeDimension.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCubeDimension.java
@@ -46,7 +46,7 @@ public class RolapCubeDimension extends RolapDimension {
 
     RolapDimension rolapDimension;
     int cubeOrdinal;
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlDimension;
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlDimension;
 
     /**
      * Creates a RolapCubeDimension.
@@ -61,7 +61,7 @@ public class RolapCubeDimension extends RolapDimension {
     public RolapCubeDimension(
         RolapCube cube,
         RolapDimension rolapDim,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim,
         String name,
         int cubeOrdinal,
         List<RolapHierarchy> hierarchyList)
@@ -108,7 +108,7 @@ public class RolapCubeDimension extends RolapDimension {
     }
 
     public RolapCube lookupFactCube(
-    		org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim, RolapCatalog schema)
+    		org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim, RolapCatalog schema)
     {
 
       if (cubeDim.getPhysicalCube() != null && cubeDim.getPhysicalCube().getName() != null) {
@@ -179,7 +179,7 @@ public class RolapCubeDimension extends RolapDimension {
         return rolapDimension.getDimensionType();
     }
 
-    public org.eclipse.daanse.rolap.mapping.model.DimensionConnector getDimensionConnector() {
+    public org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector getDimensionConnector() {
         return xmlDimension;
     }
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCubeHierarchy.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCubeHierarchy.java
@@ -78,7 +78,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
     private final RolapCubeLevel currentNullLevel;
     private RolapCubeMember currentNullMember;
     private RolapCubeMember currentAllMember;
-    private final org.eclipse.daanse.rolap.mapping.model.Query currentRelation;
+    private final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource currentRelation;
     private final RolapCubeHierarchyMemberReader reader;
     private HierarchyUsage usage;
     private final Map<String, String> aliases = new HashMap<>();
@@ -111,7 +111,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
      */
     public RolapCubeHierarchy(
         RolapCubeDimension cubeDimension,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim,
         RolapHierarchy rolapHierarchy,
         String subName,
         int ordinal)
@@ -136,7 +136,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
      */
     public RolapCubeHierarchy(
         RolapCubeDimension cubeDimension,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim,
         RolapHierarchy rolapHierarchy,
         String subName,
         int ordinal,
@@ -260,7 +260,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
      * @return Caption or description, possibly prefixed by dimension role name
      */
     private static String applyPrefix(
-    	org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim,
+    	org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim,
         String caption)
     {
         if (caption == null) {
@@ -336,19 +336,19 @@ public class RolapCubeHierarchy extends RolapHierarchy {
      * shared between all cubes with similar structure
      */
     protected void extractNewAliases(
-        org.eclipse.daanse.rolap.mapping.model.Query oldrel,
-        org.eclipse.daanse.rolap.mapping.model.Query newrel)
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource oldrel,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource newrel)
     {
         if (oldrel != null && newrel != null) {
-            if (oldrel instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery oldrelRelation
-                && newrel instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery newrelRelation) {
-                aliases.put(
-                    RelationUtil.getAlias(oldrelRelation),
-                    RelationUtil.getAlias(newrelRelation));
-            } else if (oldrel instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery oldjoin
-                && newrel instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery newjoin) {
+            if (oldrel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource oldjoin
+                && newrel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource newjoin) {
                 extractNewAliases(left(oldjoin), left(newjoin));
                 extractNewAliases(right(oldjoin), right(newjoin));
+            } else if (!(oldrel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource)
+                && !(newrel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource)) {
+                aliases.put(
+                    RelationUtil.getAlias(oldrel),
+                    RelationUtil.getAlias(newrel));
             } else {
                 throw new UnsupportedOperationException();
             }
@@ -427,7 +427,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
      * @return rolap cube hierarchy relation
      */
     @Override
-	public org.eclipse.daanse.rolap.mapping.model.Query getRelation() {
+	public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getRelation() {
         return currentRelation;
     }
 
@@ -513,7 +513,7 @@ public class RolapCubeHierarchy extends RolapHierarchy {
     }
 
     @Override
-	void init(org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlDimension) {
+	void init(org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlDimension) {
         // first init shared hierarchy
         rolapHierarchy.init(xmlDimension);
         // second init cube hierarchy

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCubeLevel.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapCubeLevel.java
@@ -103,7 +103,7 @@ public class RolapCubeLevel extends RolapLevel implements CubeLevel {
         if (parentCubeLevel != null) {
             parentCubeLevel.childCubeLevel = this;
         }
-        org.eclipse.daanse.rolap.mapping.model.Query hierarchyRel = cubeHierarchy.getRelation();
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource hierarchyRel = cubeHierarchy.getRelation();
         keyExp = convertExpression(level.getKeyExp(), hierarchyRel);
         nameExp = convertExpression(level.getNameExp(), hierarchyRel);
         captionExp = convertExpression(level.getCaptionExp(), hierarchyRel);
@@ -114,7 +114,7 @@ public class RolapCubeLevel extends RolapLevel implements CubeLevel {
 
     @Override
 	public
-	void init(org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlDimension) {
+	void init(org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlDimension) {
         if (isAll()) {
             this.levelReader = new AllLevelReaderImpl();
         } else if (getLevelType() == LevelType.NULL) {
@@ -159,7 +159,7 @@ public class RolapCubeLevel extends RolapLevel implements CubeLevel {
 
     private RolapProperty[] convertProperties(
         RolapProperty[] properties,
-        org.eclipse.daanse.rolap.mapping.model.Query rel)
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel)
     {
         if (properties == null) {
             return new RolapProperty[0];
@@ -193,7 +193,7 @@ public class RolapCubeLevel extends RolapLevel implements CubeLevel {
      */
     private SqlExpression convertExpression(
             SqlExpression exp,
-            org.eclipse.daanse.rolap.mapping.model.Query rel)
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel)
     {
         if (getHierarchy().isUsingCubeFact()) {
             // no conversion necessary
@@ -201,12 +201,12 @@ public class RolapCubeLevel extends RolapLevel implements CubeLevel {
         } else if (exp == null || rel == null) {
             return null;
         } else if (exp instanceof org.eclipse.daanse.rolap.element.RolapColumn col) {
-            if (rel instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+            if (rel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
                 return new org.eclipse.daanse.rolap.element.RolapColumn(
                     RelationUtil.getAlias(table),
                     col.getName(), col.getSortingDirection());
-            } else if (rel instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery
-                || rel instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery)
+            } else if (rel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource
+                || rel instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource)
             {
                 // need to determine correct name of alias for this level.
                 // this may be defined in level

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapDimension.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapDimension.java
@@ -120,8 +120,8 @@ public class RolapDimension extends DimensionBase {
     public RolapDimension(
         RolapCatalog schema,
         RolapCube cube,
-        org.eclipse.daanse.rolap.mapping.model.Dimension mappingDimension,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector dimensionConnector)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension mappingDimension,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector dimensionConnector)
     {
         this(
             schema,
@@ -186,7 +186,7 @@ public class RolapDimension extends DimensionBase {
         }
     }
 
-    public static String getDimensionName(org.eclipse.daanse.rolap.mapping.model.DimensionConnector mappingCubeDimension) {
+    public static String getDimensionName(org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector mappingCubeDimension) {
         return  mappingCubeDimension.getOverrideDimensionName() != null ? mappingCubeDimension.getOverrideDimensionName() : mappingCubeDimension.getDimension().getName();
     }
 
@@ -198,7 +198,7 @@ public class RolapDimension extends DimensionBase {
     /**
      * Initializes a dimension within the context of a cube.
      */
-    void init(org.eclipse.daanse.rolap.mapping.model.DimensionConnector mappingDimension) {
+    void init(org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector mappingDimension) {
         for (Hierarchy h : hierarchies) {
             if (h != null) {
                 ((RolapHierarchy) h).init(mappingDimension);

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapHierarchy.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapHierarchy.java
@@ -120,6 +120,7 @@ import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 /**
  * RolapHierarchy implements {@link Hierarchy} for a ROLAP database.
  *
@@ -150,9 +151,9 @@ public class RolapHierarchy extends HierarchyBase {
      * {@link #createMemberReader(Role)}.
      */
     private MemberReader memberReader;
-    protected org.eclipse.daanse.rolap.mapping.model.Hierarchy hierarchyMapping;
+    protected org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy hierarchyMapping;
     private String memberReaderClass;
-    protected org.eclipse.daanse.rolap.mapping.model.Query relation;
+    protected org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation;
     private Member defaultMember;
     private String defaultMemberName;
     private RolapNullMember nullMember;
@@ -276,8 +277,8 @@ public class RolapHierarchy extends HierarchyBase {
     public RolapHierarchy(
         RolapCube cube,
         RolapDimension dimension,
-        org.eclipse.daanse.rolap.mapping.model.Hierarchy xmlHierarchy,
-        org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDimensionMapping)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy xmlHierarchy,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDimensionMapping)
     {
         this(
             dimension,
@@ -293,7 +294,7 @@ public class RolapHierarchy extends HierarchyBase {
         assert !(this instanceof RolapCubeHierarchy);
 
         this.hierarchyMapping = xmlHierarchy;
-        org.eclipse.daanse.rolap.mapping.model.Query xmlHierarchyRelation = xmlHierarchy.getQuery();
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource xmlHierarchyRelation = xmlHierarchy.getQuery();
         if (xmlHierarchy.getQuery() == null
             && xmlHierarchy.getMemberReaderClass() == null
             && cube != null)
@@ -311,7 +312,7 @@ public class RolapHierarchy extends HierarchyBase {
         }
 
         this.relation = xmlHierarchyRelation;
-        if (xmlHierarchyRelation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery inlineTable) {
+        if (xmlHierarchyRelation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource inlineTable) {
             this.relation =
                 RolapUtil.convertInlineTableToRelation(
                     inlineTable,
@@ -362,14 +363,14 @@ public class RolapHierarchy extends HierarchyBase {
         }
         this.allMember.setOrdinal(0);
 
-        if (xmlHierarchy instanceof org.eclipse.daanse.rolap.mapping.model.ExplicitHierarchy eh) {
+        if (xmlHierarchy instanceof org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy eh) {
             if (eh.getLevels().isEmpty()) {
                 throw new OlapRuntimeException(MessageFormat.format(hierarchyHasNoLevels,
                         getUniqueName()));
             }
 
             Set<String> levelNameSet = new HashSet<>();
-            for (org.eclipse.daanse.rolap.mapping.model.Level level : eh.getLevels()) {
+            for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level : eh.getLevels()) {
                 if (!levelNameSet.add(level.getName())) {
                     throw new OlapRuntimeException(MessageFormat.format(hierarchyLevelNamesNotUnique,
                         getUniqueName(), level.getName()));
@@ -381,7 +382,7 @@ public class RolapHierarchy extends HierarchyBase {
                 this.levels = new ArrayList<Level>();
                 this.levels.add(allLevel);
                 int i = 1;
-                for (org.eclipse.daanse.rolap.mapping.model.Level xmlLevel : eh.getLevels()) {
+                for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level xmlLevel : eh.getLevels()) {
                     if (getKeyExp(xmlLevel) == null
                         && xmlHierarchy.getMemberReaderClass() == null)
                     {
@@ -395,13 +396,13 @@ public class RolapHierarchy extends HierarchyBase {
             } else {
                 this.levels = new ArrayList<Level>();
                 int i = 0;
-                for (org.eclipse.daanse.rolap.mapping.model.Level xmlLevel : eh.getLevels()) {
+                for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level xmlLevel : eh.getLevels()) {
                     RolapLevel rl = new RolapLevel(this, i, xmlLevel);
                     levels.add(rl);
                     i++;
                 }
             }
-        } else if (xmlHierarchy instanceof org.eclipse.daanse.rolap.mapping.model.ParentChildHierarchy pch ){
+        } else if (xmlHierarchy instanceof org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildHierarchy pch ){
             if (pch.getLevel() == null) {
                 throw new OlapRuntimeException(MessageFormat.format(hierarchyHasNoLevels,
                         getUniqueName()));
@@ -415,7 +416,7 @@ public class RolapHierarchy extends HierarchyBase {
                 this.levels = new ArrayList<Level>();
                 this.levels.add(allLevel);
                 int i = 1;
-                org.eclipse.daanse.rolap.mapping.model.Level xmlLevel = pch.getLevel();
+                org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level xmlLevel = pch.getLevel();
                 
                 if (getKeyExp(xmlLevel) == null
                     && xmlHierarchy.getMemberReaderClass() == null)
@@ -426,7 +427,7 @@ public class RolapHierarchy extends HierarchyBase {
                 
                 StringBuilder sb = new StringBuilder();
                 sb.append(xmlLevel.getName()).append(i);
-                RolapLevel l = new RolapLevel(sb.toString(), LevelUtil.getParentExp(pch), pch.getNullParentValue(), pch.getParentChildLink(), this, i,
+                RolapLevel l = new RolapLevel(sb.toString(), LevelUtil.getParentExp(pch, this), pch.getNullParentValue(), pch.getParentChildLink(), this, i,
                         pch.isParentAsLeafEnable(), pch.getParentAsLeafNameFormat(), xmlLevel);
                 levels.add(l);
                 Map<Integer, Set<RolapMember>> childMap = getChildMap((RolapLevel)l);
@@ -442,10 +443,10 @@ public class RolapHierarchy extends HierarchyBase {
             } else {
                 this.levels = new ArrayList<Level>();
                 int i = 0;
-                org.eclipse.daanse.rolap.mapping.model.Level xmlLevel = pch.getLevel();
+                org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level xmlLevel = pch.getLevel();
                 StringBuilder sb = new StringBuilder();
                 sb.append(xmlLevel.getName()).append(i+1);
-                RolapLevel l = new RolapLevel(sb.toString(), LevelUtil.getParentExp(pch), pch.getNullParentValue(), pch.getParentChildLink(), this, i,
+                RolapLevel l = new RolapLevel(sb.toString(), LevelUtil.getParentExp(pch, this), pch.getNullParentValue(), pch.getParentChildLink(), this, i,
                         pch.isParentAsLeafEnable(), pch.getParentAsLeafNameFormat(), xmlLevel);
                 levels.add(l);
                 Map<Integer, Set<RolapMember>> childMap = getChildMap((RolapLevel)l);
@@ -561,7 +562,7 @@ public class RolapHierarchy extends HierarchyBase {
     /**
      * Initializes a hierarchy within the context of a cube.
      */
-    void init(org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlDimension) {
+    void init(org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlDimension) {
         // first create memberReader
         if (this.memberReader == null) {
             this.memberReader = getRolapCatalog().createMemberReader(
@@ -658,10 +659,10 @@ public class RolapHierarchy extends HierarchyBase {
      * if this hierarchy has no table, return the cube's fact-table;
      * otherwise, returns null.
      */
-    public org.eclipse.daanse.rolap.mapping.model.RelationalQuery getUniqueTable() {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery r) {
+    public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getUniqueTable() {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource r) {
             return r;
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery) {
+        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) {
             return null;
         } else {
             throw Util.newInternal(
@@ -673,27 +674,69 @@ public class RolapHierarchy extends HierarchyBase {
         return (relation != null) && getTable(tableName, relation) != null;
     }
 
-    org.eclipse.daanse.rolap.mapping.model.RelationalQuery getTable(String tableName) {
+    /**
+     * Finds the alias used in this hierarchy's join tree to reference the given
+     * physical table (or view). This lets a level whose column is owned by a
+     * shared physical table resolve to the per-hierarchy alias (e.g. a shared
+     * {@code region} table aliased {@code store_region} in one hierarchy and
+     * {@code customer_region} in another). Returns the owner's bare name when
+     * the tree does not alias it, or when {@code owner} is null.
+     */
+    public String findAliasForOwner(
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet owner)
+    {
+        if (owner == null) {
+            return null;
+        }
+        if (relation != null) {
+            String alias = findAliasForOwner(owner, relation);
+            if (alias != null) {
+                return alias;
+            }
+        }
+        return owner.getName();
+    }
+
+    private static String findAliasForOwner(
+        org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet owner,
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationOrJoin)
+    {
+        if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+            String a = findAliasForOwner(owner, left(join));
+            if (a != null) {
+                return a;
+            }
+            return findAliasForOwner(owner, right(join));
+        }
+        if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table
+            && table.getTable() == owner)
+        {
+            return table.getAlias() != null ? table.getAlias() : owner.getName();
+        }
+        return null;
+    }
+
+    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getTable(String tableName) {
         return relation == null ? null : getTable(tableName, relation);
     }
 
-    private static org.eclipse.daanse.rolap.mapping.model.RelationalQuery getTable(
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getTable(
         String tableName,
-        org.eclipse.daanse.rolap.mapping.model.Query relationOrJoin)
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationOrJoin)
     {
-        if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery relation) {
+        if (relationOrJoin instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel = getTable(tableName, left(join));
+            if (rel != null) {
+                return rel;
+            }
+            return getTable(tableName, right(join));
+        } else {
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = relationOrJoin;
             if (tableName.equals(RelationUtil.getAlias(relation)) || tableName.equals(RelationUtil.getTableName(relation))) {
                 return relation;
             } else {
                 return null;
             }
-        } else {
-        	org.eclipse.daanse.rolap.mapping.model.JoinQuery join = (org.eclipse.daanse.rolap.mapping.model.JoinQuery) relationOrJoin;
-        	org.eclipse.daanse.rolap.mapping.model.RelationalQuery rel = getTable(tableName, left(join));
-            if (rel != null) {
-                return rel;
-            }
-            return getTable(tableName, right(join));
         }
     }
 
@@ -701,15 +744,15 @@ public class RolapHierarchy extends HierarchyBase {
         return (RolapCatalog) dimension.getCatalog();
     }
 
-    public org.eclipse.daanse.rolap.mapping.model.Query getRelation() {
+    public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getRelation() {
         return relation;
     }
 
-    public void setRelation(org.eclipse.daanse.rolap.mapping.model.Query relation) {
+    public void setRelation(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
         this.relation = relation;
     }
 
-    public org.eclipse.daanse.rolap.mapping.model.Hierarchy getHierarchyMapping() {
+    public org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy getHierarchyMapping() {
         return hierarchyMapping;
     }
 
@@ -838,8 +881,8 @@ public class RolapHierarchy extends HierarchyBase {
                     .append(" to query: it does not have a <Table>, <View> or <Join>").toString());
         }
         final boolean failIfExists = false;
-        org.eclipse.daanse.rolap.mapping.model.Query subRelation = relation;
-        if (getRelation() instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery &&  expression != null) {
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource subRelation = relation;
+        if (getRelation() instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource &&  expression != null) {
                 subRelation =
                     relationSubsetInverse(relation, getTableAlias(expression));
         }
@@ -867,8 +910,8 @@ public class RolapHierarchy extends HierarchyBase {
         }
         query.registerRootRelation(getRelation());
         final boolean failIfExists = false;
-        org.eclipse.daanse.rolap.mapping.model.Query subRelation = getRelation();
-        if (getRelation() instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery && expression != null) {
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource subRelation = getRelation();
+        if (getRelation() instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource && expression != null) {
             // Suppose relation is
             //   (((A join B) join C) join D)
             // and the fact table is
@@ -907,7 +950,7 @@ public class RolapHierarchy extends HierarchyBase {
                     .append(" to query: it does not have a <Table>, <View> or <Join>").toString());
         }
         final boolean failIfExists = false;
-        org.eclipse.daanse.rolap.mapping.model.Query subRelation = null;
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource subRelation = null;
         if (table != null) {
             // Suppose relation is
             //   (((A join B) join C) join D)
@@ -952,21 +995,21 @@ public class RolapHierarchy extends HierarchyBase {
      * @return the smallest containing relation or null if no matching table
      * is found in relation
      */
-    private static org.eclipse.daanse.rolap.mapping.model.Query relationSubsetInverse(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationSubsetInverse(
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         String alias)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery table) {
-            return RelationUtil.getAlias(table).equals(alias)
-                ? relation
-                : null;
-
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
-        	org.eclipse.daanse.rolap.mapping.model.Query leftRelation =
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource leftRelation =
                 relationSubsetInverse(left(join), alias);
             return (leftRelation == null)
                 ? relationSubsetInverse(right(join), alias)
                 : join;
+
+        } else if (relation != null) {
+            return RelationUtil.getAlias(relation).equals(alias)
+                ? relation
+                : null;
 
         } else {
             throw Util.newInternal("bad relation type " + relation);
@@ -982,17 +1025,12 @@ public class RolapHierarchy extends HierarchyBase {
      * @return the smallest containing relation or null if no matching table
      * is found in relation
      */
-    private static org.eclipse.daanse.rolap.mapping.model.Query relationSubset(
-    		org.eclipse.daanse.rolap.mapping.model.Query relation,
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationSubset(
+    		org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         String alias)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.RelationalQuery table) {
-            return RelationUtil.getAlias(table).equals(alias)
-                ? relation
-                : null;
-
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
-            org.eclipse.daanse.rolap.mapping.model.Query rightRelation =
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+            org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rightRelation =
                 relationSubset(right(join), alias);
             if (rightRelation == null) {
                 return relationSubset(left(join), alias);
@@ -1002,6 +1040,10 @@ public class RolapHierarchy extends HierarchyBase {
                     ? join
                     : rightRelation;
             }
+        } else if (relation != null) {
+            return RelationUtil.getAlias(relation).equals(alias)
+                ? relation
+                : null;
         } else {
             throw Util.newInternal("bad relation type " + relation);
         }
@@ -1017,19 +1059,19 @@ public class RolapHierarchy extends HierarchyBase {
      * @return the smallest containing relation or null if no matching table
      * is found in relation
      */
-    private static org.eclipse.daanse.rolap.mapping.model.Query lookupRelationSubset(
-        org.eclipse.daanse.rolap.mapping.model.Query relation,
+    private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource lookupRelationSubset(
+        org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
         RolapStar.Table targetTable)
     {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery table) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource table) {
             if (table.getTable().equals(targetTable.getTable())) {
                 return relation;
             } else {
                 // Not the same table if table names are different
                 return null;
             }
-        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery join) {
-        	org.eclipse.daanse.rolap.mapping.model.Query rightRelation =
+        } else if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join) {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rightRelation =
                 lookupRelationSubset(right(join), targetTable);
             if (rightRelation == null) {
                 // Keep searching left.
@@ -1316,7 +1358,7 @@ public class RolapHierarchy extends HierarchyBase {
      */
     public RolapDimension createClosedPeerDimension(
         RolapLevel src,
-        org.eclipse.daanse.rolap.mapping.model.ParentChildLink clos)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildLink clos)
     {
         // REVIEW (mb): What about attribute primaryKeyTable?
 
@@ -1336,13 +1378,13 @@ public class RolapHierarchy extends HierarchyBase {
         peerHier.allMember = (RolapMemberBase) getAllMember();
         peerHier.allLevelName = getAllLevelName();
         peerHier.sharedHierarchyName = getSharedHierarchyName();
-        org.eclipse.daanse.rolap.mapping.model.JoinQuery join = RolapMappingFactory.eINSTANCE.createJoinQuery();
+        org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource join = SourceFactory.eINSTANCE.createJoinSource();
 
-        org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement leftElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+        org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement leftElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
         leftElement.setKey(PojoUtil.getColumn(clos.getParentColumn()));
         leftElement.setQuery(PojoUtil.copy(clos.getTable()));
 
-        org.eclipse.daanse.rolap.mapping.model.JoinedQueryElement rightElement = RolapMappingFactory.eINSTANCE.createJoinedQueryElement();
+        org.eclipse.daanse.rolap.mapping.model.database.source.JoinedQueryElement rightElement = SourceFactory.eINSTANCE.createJoinedQueryElement();
         rightElement.setKey(PojoUtil.getColumn(clos.getChildColumn()));
         rightElement.setQuery(PojoUtil.copy(relation));
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapLevel.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapLevel.java
@@ -34,6 +34,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import java.sql.Types;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType;
+import org.eclipse.daanse.cwm.util.resource.relational.SqlSimpleTypes;
 import org.eclipse.daanse.jdbc.db.dialect.api.type.BestFitColumnType;
 import org.eclipse.daanse.jdbc.db.dialect.api.type.Datatype;
 import org.eclipse.daanse.olap.api.agg.Segment;
@@ -65,7 +69,7 @@ import org.eclipse.daanse.rolap.common.star.RolapSqlExpression;
 import org.eclipse.daanse.rolap.common.util.ExpressionUtil;
 import org.eclipse.daanse.rolap.common.util.LevelUtil;
 import org.eclipse.daanse.rolap.common.util.RelationUtil;
-import org.eclipse.daanse.rolap.mapping.model.ColumnInternalDataType;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,13 +129,13 @@ public class RolapLevel extends LevelBase {
 
     /** Condition under which members are hidden. */
     private final HideMemberCondition hideMemberCondition;
-    protected final org.eclipse.daanse.rolap.mapping.model.ParentChildLink xmlClosure;
+    protected final org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildLink xmlClosure;
     private final MetaData metaData;
     private final BestFitColumnType internalType; // may be null
 
     private final boolean parentAsLeafEnable;
     private final String parentAsLeafNameFormat;
-    protected org.eclipse.daanse.rolap.mapping.model.Level levelMapping;
+    protected org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level levelMapping;
 
     /**
      * Creates a level.
@@ -154,7 +158,7 @@ public class RolapLevel extends LevelBase {
         List<SqlExpression> ordinalExps,
         SqlExpression parentExp,
         String nullParentValue,
-        org.eclipse.daanse.rolap.mapping.model.ParentChildLink mappingClosure,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildLink mappingClosure,
         RolapProperty[] properties,
         int flags,
         Datatype datatype,
@@ -209,7 +213,7 @@ public class RolapLevel extends LevelBase {
         List<? extends SqlExpression> ordinalExps,
         SqlExpression parentExp,
         String nullParentValue,
-        org.eclipse.daanse.rolap.mapping.model.ParentChildLink mappingClosure,
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildLink mappingClosure,
         RolapProperty[] properties,
         int flags,
         Datatype datatype,
@@ -443,12 +447,12 @@ public class RolapLevel extends LevelBase {
             String name,
             RolapSqlExpression parentExp,
             String nullParentValue,
-            org.eclipse.daanse.rolap.mapping.model.ParentChildLink parentChildLink,
+            org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildLink parentChildLink,
             RolapHierarchy hierarchy,
             int depth,
             boolean parentAsLeafEnable,
             String parentAsLeafNameFormat,
-            org.eclipse.daanse.rolap.mapping.model.Level mappingLevel)
+            org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level mappingLevel)
     {
 
         this(
@@ -458,14 +462,14 @@ public class RolapLevel extends LevelBase {
             mappingLevel.isVisible(),
             mappingLevel.getDescription(),
             depth,
-            LevelUtil.getKeyExp(mappingLevel),
-            LevelUtil.getNameExp(mappingLevel),
-            LevelUtil.getCaptionExp(mappingLevel),
-            LevelUtil.getOrdinalExp(mappingLevel),
+            LevelUtil.getKeyExp(mappingLevel, hierarchy),
+            LevelUtil.getNameExp(mappingLevel, hierarchy),
+            LevelUtil.getCaptionExp(mappingLevel, hierarchy),
+            LevelUtil.getOrdinalExp(mappingLevel, hierarchy),
             parentExp,
             nullParentValue,
             parentChildLink,
-            createProperties(mappingLevel),
+            createProperties(mappingLevel, hierarchy),
             (mappingLevel.isUniqueMembers() ? FLAG_UNIQUE : 0),
             getType(mappingLevel),
             null,
@@ -498,7 +502,7 @@ public class RolapLevel extends LevelBase {
     public RolapLevel(
         RolapHierarchy hierarchy,
         int depth,
-        org.eclipse.daanse.rolap.mapping.model.Level mappingLevel)
+        org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level mappingLevel)
     {
 
         this(mappingLevel.getName(),
@@ -518,7 +522,7 @@ public class RolapLevel extends LevelBase {
             int depth,
             boolean parentAsLeafEnable,
             String parentAsLeafNameFormat,
-            org.eclipse.daanse.rolap.mapping.model.Level mappingLevel){
+            org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level mappingLevel){
 
             this(name,
                     null,
@@ -531,14 +535,42 @@ public class RolapLevel extends LevelBase {
 
     }
 
-    private static Datatype getType(org.eclipse.daanse.rolap.mapping.model.Level mappingLevel) {
+    private static Datatype getType(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level mappingLevel) {
         if (mappingLevel.getColumnType() != null && !ColumnInternalDataType.UNDEFINED.equals(mappingLevel.getColumnType()) ) {
             if (ColumnInternalDataType.STRING.equals(mappingLevel.getColumnType())) {
-                return org.eclipse.daanse.jdbc.db.dialect.api.type.Datatype.VARCHAR;
+                return Datatype.VARCHAR;
             }
-            return org.eclipse.daanse.jdbc.db.dialect.api.type.Datatype.fromValue(mappingLevel.getColumnType().getLiteral());
+            return Datatype.fromValue(mappingLevel.getColumnType().getLiteral());
         }
-        return org.eclipse.daanse.jdbc.db.dialect.api.type.Datatype.fromValue(mappingLevel.getColumn().getType().getLiteral());
+        // Classify by JDBC type code from CWM SQLSimpleType. Names vary
+        // (SQL-99 "CHARACTER VARYING" vs RDBMS "VARCHAR") but the JDBC code
+        // is stable, so we map through java.sql.Types.
+        if (mappingLevel.getColumn() != null
+                && mappingLevel.getColumn().getType() instanceof SQLSimpleType st) {
+            return jdbcTypeToDatatype(SqlSimpleTypes.jdbcType(st));
+        }
+        return Datatype.NUMERIC;
+    }
+
+    private static Datatype jdbcTypeToDatatype(int jdbcType) {
+        return switch (jdbcType) {
+            case Types.CHAR, Types.VARCHAR, Types.LONGVARCHAR,
+                 Types.NCHAR, Types.NVARCHAR, Types.LONGNVARCHAR,
+                 Types.CLOB, Types.NCLOB -> Datatype.VARCHAR;
+            case Types.TINYINT, Types.SMALLINT -> Datatype.SMALLINT;
+            case Types.INTEGER -> Datatype.INTEGER;
+            case Types.BIGINT -> Datatype.BIGINT;
+            case Types.NUMERIC -> Datatype.NUMERIC;
+            case Types.DECIMAL -> Datatype.DECIMAL;
+            case Types.FLOAT -> Datatype.FLOAT;
+            case Types.REAL -> Datatype.REAL;
+            case Types.DOUBLE -> Datatype.DOUBLE;
+            case Types.BOOLEAN, Types.BIT -> Datatype.BOOLEAN;
+            case Types.DATE -> Datatype.DATE;
+            case Types.TIME, Types.TIME_WITH_TIMEZONE -> Datatype.TIME;
+            case Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE -> Datatype.TIMESTAMP;
+            default -> Datatype.NUMERIC;
+        };
     }
 
     private void setLevelInProperties() {
@@ -551,10 +583,10 @@ public class RolapLevel extends LevelBase {
     }
 
     // helper for constructor
-    private static RolapProperty[] createProperties(org.eclipse.daanse.rolap.mapping.model.Level xmlLevel)
+    private static RolapProperty[] createProperties(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level xmlLevel, RolapHierarchy hierarchy)
     {
         List<RolapProperty> list = new ArrayList<>();
-        final RolapSqlExpression nameExp = LevelUtil.getNameExp(xmlLevel);
+        final RolapSqlExpression nameExp = LevelUtil.getNameExp(xmlLevel, hierarchy);
 
         if (nameExp != null) {
             list.add(
@@ -564,7 +596,7 @@ public class RolapLevel extends LevelBase {
                     StandardProperty.NAME.getDescription(), null));
         }
         for (int i = 0; i < xmlLevel.getMemberProperties().size(); i++) {
-        	org.eclipse.daanse.rolap.mapping.model.MemberProperty xmlProperty = xmlLevel.getMemberProperties().get(i);
+        	org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.MemberProperty xmlProperty = xmlLevel.getMemberProperties().get(i);
 
             FormatterCreateContext formatterContext =
                     new FormatterCreateContext.Builder(xmlProperty.getName())
@@ -621,7 +653,7 @@ public class RolapLevel extends LevelBase {
     private void checkColumn(org.eclipse.daanse.rolap.element.RolapColumn nameColumn) {
         final RolapHierarchy rolapHierarchy = (RolapHierarchy) hierarchy;
         if (nameColumn.getTable() == null) {
-            final org.eclipse.daanse.rolap.mapping.model.RelationalQuery table = rolapHierarchy.getUniqueTable();
+            final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource table = rolapHierarchy.getUniqueTable();
             if (table == null) {
                 throw Util.newError(
                     new StringBuilder("must specify a table for level ").append(getUniqueName())
@@ -637,7 +669,7 @@ public class RolapLevel extends LevelBase {
         }
     }
 
-    public void init(org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlDimension) {
+    public void init(org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlDimension) {
         if (xmlClosure != null) {
             final RolapDimension dimension = ((RolapHierarchy) hierarchy)
                 .createClosedPeerDimension(this, xmlClosure);
@@ -687,7 +719,7 @@ public class RolapLevel extends LevelBase {
         return members != null ? members: List.of();
     }
 
-    public org.eclipse.daanse.rolap.mapping.model.Level getLevelMapping() {
+    public org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level getLevelMapping() {
         return levelMapping;
     }
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapPhysicalCube.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapPhysicalCube.java
@@ -68,6 +68,7 @@ import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
 public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
 
     private final static String measureOrdinalsNotUnique = "Cube ''{0}'': Ordinal {1} is not unique: ''{2}'' and ''{3}''";
@@ -76,10 +77,10 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
     /**
      * Creates a RolapCube from a regular cube.
      */
-    RolapPhysicalCube(RolapCatalog catalog, org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping, org.eclipse.daanse.rolap.mapping.model.PhysicalCube cubeMapping,
+    RolapPhysicalCube(RolapCatalog catalog, org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping, org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube cubeMapping,
             Context context) {
         super(catalog, catalogMapping, cubeMapping, cubeMapping.isCache(),
-                (org.eclipse.daanse.rolap.mapping.model.RelationalQuery) cubeMapping.getQuery(), context);
+                (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) cubeMapping.getQuery(), context);
 
         if (getFact() == null) {
             throw Util.newError(
@@ -125,17 +126,17 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
         }
     }
 
-    private List<RolapMember> initMeasures(org.eclipse.daanse.rolap.mapping.model.PhysicalCube cubeMapping) {
+    private List<RolapMember> initMeasures(org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube cubeMapping) {
         RolapLevel measuresLevel = this.getMeasuresHierarchy().newMeasuresLevel();
 
-        List<? extends org.eclipse.daanse.rolap.mapping.model.BaseMeasure> measureMappings = cubeMapping.getMeasureGroups().stream()
-                .map(org.eclipse.daanse.rolap.mapping.model.MeasureGroup::getMeasures).flatMap(Collection::stream).toList();
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BaseMeasure> measureMappings = cubeMapping.getMeasureGroups().stream()
+                .map(org.eclipse.daanse.rolap.mapping.model.olap.cube.MeasureGroup::getMeasures).flatMap(Collection::stream).toList();
 
         List<RolapMember> measureList = new ArrayList<>(measureMappings.size());
 
         AtomicInteger ai = new AtomicInteger();
         Member defaultMeasure = null;
-        for (org.eclipse.daanse.rolap.mapping.model.BaseMeasure measureMapping : measureMappings) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BaseMeasure measureMapping : measureMappings) {
             RolapBaseCubeMeasure measure = createMeasure(cubeMapping, measuresLevel, ai.getAndIncrement(),
                     measureMapping);
             measureList.add(measure);
@@ -165,7 +166,7 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
             internalUsage.setValue("For internal use");
             List<Annotation> annotations = new ArrayList<>();
             annotations.add(internalUsage);
-            final org.eclipse.daanse.rolap.mapping.model.CountMeasure mappingMeasure = RolapMappingFactory.eINSTANCE.createCountMeasure();
+            final org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CountMeasure mappingMeasure = MeasureFactory.eINSTANCE.createCountMeasure();
             mappingMeasure.setName("Fact Count");
             mappingMeasure.setVisible(false);
             mappingMeasure.getAnnotations().addAll(annotations);
@@ -180,12 +181,12 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
         return measureList;
     }
 
-    private void initWritebackTables(org.eclipse.daanse.rolap.mapping.model.PhysicalCube cubeMapping) {
+    private void initWritebackTables(org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube cubeMapping) {
         if (cubeMapping.getWritebackTable() != null) {
-        	org.eclipse.daanse.rolap.mapping.model.WritebackTable writebackTable = cubeMapping.getWritebackTable();
+        	org.eclipse.daanse.rolap.mapping.model.database.writeback.WritebackTable writebackTable = cubeMapping.getWritebackTable();
             List<RolapWritebackColumn> columns = new ArrayList<>();
 
-            for (org.eclipse.daanse.rolap.mapping.model.WritebackAttribute writebackAttribute : writebackTable.getWritebackAttribute()) {
+            for (org.eclipse.daanse.rolap.mapping.model.database.writeback.WritebackAttribute writebackAttribute : writebackTable.getWritebackAttribute()) {
 
                 Dimension dimension = null;
                 for (Dimension currentDimension : this.getDimensions()) {
@@ -204,7 +205,7 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
                 columns.add(new RolapWritebackAttribute(dimension, writebackAttribute.getColumn()));
 
             }
-            for (org.eclipse.daanse.rolap.mapping.model.WritebackMeasure writebackMeasure : writebackTable.getWritebackMeasure()) {
+            for (org.eclipse.daanse.rolap.mapping.model.database.writeback.WritebackMeasure writebackMeasure : writebackTable.getWritebackMeasure()) {
                 Member measure = null;
                 for (Member currentMeasure : this.getMeasures()) {
                     if (currentMeasure instanceof RolapBaseCubeMeasure rbcm
@@ -225,12 +226,12 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
         }
     }
 
-    private void initActions(org.eclipse.daanse.rolap.mapping.model.PhysicalCube cubeMapping) {
-        for (org.eclipse.daanse.rolap.mapping.model.Action mappingAction : cubeMapping.getAction()) {
-            if (mappingAction instanceof org.eclipse.daanse.rolap.mapping.model.DrillThroughAction mappingDrillThroughAction) {
+    private void initActions(org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube cubeMapping) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.cube.action.Action mappingAction : cubeMapping.getAction()) {
+            if (mappingAction instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.action.DrillThroughAction mappingDrillThroughAction) {
                 List<DrillThroughColumn> columns = new ArrayList<>();
 
-                for (org.eclipse.daanse.rolap.mapping.model.DrillThroughAttribute mappingDrillThroughAttribute : mappingDrillThroughAction
+                for (org.eclipse.daanse.rolap.mapping.model.olap.cube.action.DrillThroughAttribute mappingDrillThroughAttribute : mappingDrillThroughAction
                         .getDrillThroughAttribute()) {
                     Dimension dimension = null;
                     Hierarchy hierarchy = null;
@@ -297,7 +298,7 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
                     columns.add(new RolapDrillThroughAttribute(dimension, hierarchy, level, property));
 
                 }
-                for (org.eclipse.daanse.rolap.mapping.model.BaseMeasure drillThroughMeasure : mappingDrillThroughAction.getDrillThroughMeasure()) {
+                for (org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BaseMeasure drillThroughMeasure : mappingDrillThroughAction.getDrillThroughMeasure()) {
                     Member measure = null;
                     for (Member currntMeasure : this.getMeasures()) {
                         if (currntMeasure.getName().equals(drillThroughMeasure.getName())) {
@@ -329,24 +330,24 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
      * @param measureMapping XML measure
      * @return Measure
      */
-    private RolapBaseCubeMeasure createMeasure(org.eclipse.daanse.rolap.mapping.model.Cube cubeMapping, RolapLevel measuresLevel, int ordinal,
-            final org.eclipse.daanse.rolap.mapping.model.BaseMeasure measureMapping) {
-    	org.eclipse.daanse.rolap.mapping.model.Column columnMapping;
+    private RolapBaseCubeMeasure createMeasure(org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cubeMapping, RolapLevel measuresLevel, int ordinal,
+            final org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BaseMeasure measureMapping) {
+    	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column columnMapping;
         RolapSqlExpression measureExp = null;
-        if (measureMapping instanceof org.eclipse.daanse.rolap.mapping.model.ColumnBaseMeasure cmm) {
+        if (measureMapping instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.ColumnBaseMeasure cmm) {
             columnMapping = cmm.getColumn();
-            if (columnMapping instanceof org.eclipse.daanse.rolap.mapping.model.PhysicalColumn pc) {
-                measureExp = new RolapColumn(getAlias(getFact()), pc.getName());
-            } else if (columnMapping instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionColumn scm) {
+            if (columnMapping instanceof org.eclipse.daanse.rolap.mapping.model.database.relational.ExpressionColumn scm) {
                 measureExp = new RolapSqlExpression(scm);
-            } else if (measureMapping instanceof org.eclipse.daanse.rolap.mapping.model.CountMeasure) {
+            } else if (columnMapping instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.Column pc) {
+                measureExp = new RolapColumn(getAlias(getFact()), pc.getName());
+            } else if (measureMapping instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.CountMeasure) {
                 // it's ok if count has no expression; it means 'count(*)'
                 measureExp = null;
             } else {
                 throw new BadMeasureSourceException(cubeMapping.getName(), measureMapping.getName());
             }
         }
-        if (measureMapping instanceof org.eclipse.daanse.rolap.mapping.model.SQLExpressionBaseMeasure cmm) {
+        if (measureMapping instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.SQLExpressionBaseMeasure cmm) {
             if (cmm.getColumn() != null) {
                 measureExp = new RolapSqlExpression(cmm.getColumn());
             } else {
@@ -406,7 +407,7 @@ public class RolapPhysicalCube extends RolapCube implements PhysicalCube {
     /**
      * Post-initialization, doing things which cannot be done in the constructor.
      */
-    private void init(org.eclipse.daanse.rolap.mapping.model.Cube mappingCube, final List<RolapMember> memberList) {
+    private void init(org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube mappingCube, final List<RolapMember> memberList) {
         // Load calculated members and named sets.
         // (We cannot do this in the constructor, because
         // cannot parse the generated query, because the schema has not been

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapVirtualCube.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapVirtualCube.java
@@ -55,7 +55,7 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
     /**
      * Creates a RolapCube from a virtual cube.
      */
-    RolapVirtualCube(RolapCatalog catalog, org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping, org.eclipse.daanse.rolap.mapping.model.VirtualCube virtualCubeMapping,
+    RolapVirtualCube(RolapCatalog catalog, org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping, org.eclipse.daanse.rolap.mapping.model.olap.cube.VirtualCube virtualCubeMapping,
             Context context) {
         super(catalog, catalogMapping, virtualCubeMapping, true, null, context);
         // Since Measure and VirtualCubeMeasure cannot
@@ -68,13 +68,13 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
 
         this.setCubeUsages(new RolapCubeUsages(virtualCubeMapping.getCubeUsages()));
 
-        HashMap<String, org.eclipse.daanse.rolap.mapping.model.Member> measureHash = new HashMap<>();
+        HashMap<String, org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Member> measureHash = new HashMap<>();
 
         List<RolapVirtualCubeMeasure> origMeasureList = getOriginMeasureList(catalog, virtualCubeMapping,
             measuresLevel, measureHash);
-        Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember>> calculatedMembersMap = getOriginCalculatedMemberMap(catalog,
+        Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember>> calculatedMembersMap = getOriginCalculatedMemberMap(catalog,
             virtualCubeMapping, measureHash);
-        List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> origCalcMeasureList = calculatedMembersMap.entrySet().stream().map(Map.Entry::getValue).flatMap(Collection::stream).toList();
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> origCalcMeasureList = calculatedMembersMap.entrySet().stream().map(Map.Entry::getValue).flatMap(Collection::stream).toList();
         // Must init the dimensions before dealing with calculated members
         init(virtualCubeMapping.getDimensionConnectors());
 
@@ -88,7 +88,7 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
 
         // Add the original calculated members from the base cubes to our
         // list of calculated members
-        List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember> mappingCalculatedMemberList = new ArrayList<>(origCalcMeasureList);
+        List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> mappingCalculatedMemberList = new ArrayList<>(origCalcMeasureList);
         mappingCalculatedMemberList.addAll(virtualCubeMapping.getCalculatedMembers());
 
         // Resolve all calculated members relative to this virtual cube,
@@ -104,10 +104,10 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
         // retrieve calculated member source cube
         // set it appropriate rolap calculated measure
         Map<String, RolapHierarchy.RolapCalculatedMeasure> calcMeasuresWithBaseCube = new HashMap<>();
-        for (Map.Entry<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember>> entry : calculatedMembersMap.entrySet()) {
+        for (Map.Entry<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember>> entry : calculatedMembersMap.entrySet()) {
             RolapCube rolapCube = entry.getKey();
-            List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember> calculatedMembers = entry.getValue();
-            for (org.eclipse.daanse.rolap.mapping.model.CalculatedMember calculatedMember : calculatedMembers) {
+            List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> calculatedMembers = entry.getValue();
+            for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember calculatedMember : calculatedMembers) {
                 List<Member> measures = rolapCube.getMeasures();
                 for (Member measure : measures) {
                     if (measure instanceof RolapHierarchy.RolapCalculatedMeasure calculatedMeasure
@@ -125,7 +125,7 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
                 new MeasureMemberSource(this.getMeasuresHierarchy(), Util.<RolapMember>cast(origMeasureList))));
 
 
-        List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> mappingVirtualCubeCalculatedMemberList = virtualCubeMapping
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> mappingVirtualCubeCalculatedMemberList = virtualCubeMapping
                 .getCalculatedMembers();
         if (!vcHasAllCalcMembers(origCalcMeasureList, mappingVirtualCubeCalculatedMemberList)) {
             // Remove from the calculated members array
@@ -161,7 +161,7 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
                         .setBaseCube(calcMeasuresWithBaseCube.get(calcMeasure.getUniqueName()).getBaseCube());
             }
 
-            org.eclipse.daanse.rolap.mapping.model.Member mappingMeasure = measureHash.get(calcMeasure.getUniqueName());
+            org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Member mappingMeasure = measureHash.get(calcMeasure.getUniqueName());
             if (mappingMeasure != null) {
                 Boolean visible = mappingMeasure.isVisible();
                 if (visible != null) {
@@ -183,12 +183,12 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
     }
 
     private List<RolapVirtualCubeMeasure> getMesuresFromCalculatedmembers(
-            Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember>> calculatedMembersMap, RolapLevel measuresLevel) {
+            Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember>> calculatedMembersMap, RolapLevel measuresLevel) {
         List<RolapVirtualCubeMeasure> measureList = new ArrayList<RolapVirtualCubeMeasure>();
-        for (Map.Entry<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember>> entry : calculatedMembersMap.entrySet()) {
+        for (Map.Entry<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember>> entry : calculatedMembersMap.entrySet()) {
             RolapPhysicalCube baseCube = entry.getKey();
-            List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember> mappingCalculatedMemberList = calculatedMembersMap.get(baseCube);
-            Query queryExp = resolveCalcMembers(mappingCalculatedMemberList, Collections.<org.eclipse.daanse.rolap.mapping.model.NamedSet>emptyList(),
+            List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> mappingCalculatedMemberList = calculatedMembersMap.get(baseCube);
+            Query queryExp = resolveCalcMembers(mappingCalculatedMemberList, Collections.<org.eclipse.daanse.rolap.mapping.model.olap.dimension.NamedSet>emptyList(),
                     baseCube, false);
             MeasureFinder measureFinder = new MeasureFinder(this, baseCube, measuresLevel, getCatalog());
             queryExp.accept(measureFinder);
@@ -197,12 +197,12 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
         return measureList;
     }
 
-    private Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember>> getOriginCalculatedMemberMap(final RolapCatalog catalog,
-            final org.eclipse.daanse.rolap.mapping.model.VirtualCube virtualCubeMapping, HashMap<String, org.eclipse.daanse.rolap.mapping.model.Member> measureHash) {
-        Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember>> calculatedMembersMap = new TreeMap<>(new RolapCubeComparator());
-        List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> cm = virtualCubeMapping.getReferencedCalculatedMembers();
+    private Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember>> getOriginCalculatedMemberMap(final RolapCatalog catalog,
+            final org.eclipse.daanse.rolap.mapping.model.olap.cube.VirtualCube virtualCubeMapping, HashMap<String, org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Member> measureHash) {
+        Map<RolapPhysicalCube, List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember>> calculatedMembersMap = new TreeMap<>(new RolapCubeComparator());
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> cm = virtualCubeMapping.getReferencedCalculatedMembers();
         if (cm != null) {
-            for (org.eclipse.daanse.rolap.mapping.model.CalculatedMember calculatedMember : cm) {
+            for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember calculatedMember : cm) {
                 measureHash.put(calculatedMember.getName(), calculatedMember);
                 if (calculatedMember.getCube() != null) {
                     RolapCube cube = catalog.lookupCube(calculatedMember.getCube());
@@ -223,7 +223,7 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
                                     this.getMeasuresHierarchy().setDefaultMember(cubeMeasure);
                                 }
                                 found = true;
-                                List<org.eclipse.daanse.rolap.mapping.model.CalculatedMember> memberList = calculatedMembersMap.get(cube);
+                                List<org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> memberList = calculatedMembersMap.get(cube);
                                 if (memberList == null) {
                                     memberList = new ArrayList<>();
                                 }
@@ -250,11 +250,11 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
         return calculatedMembersMap;
     }
 
-    private List<RolapVirtualCubeMeasure> getOriginMeasureList(RolapCatalog catalog, org.eclipse.daanse.rolap.mapping.model.VirtualCube virtualCubeMapping, RolapLevel measuresLevel,
-            HashMap<String, org.eclipse.daanse.rolap.mapping.model.Member> measureHash) {
+    private List<RolapVirtualCubeMeasure> getOriginMeasureList(RolapCatalog catalog, org.eclipse.daanse.rolap.mapping.model.olap.cube.VirtualCube virtualCubeMapping, RolapLevel measuresLevel,
+            HashMap<String, org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Member> measureHash) {
         List<RolapVirtualCubeMeasure> origMeasureList = new ArrayList<>();
-        List<? extends org.eclipse.daanse.rolap.mapping.model.BaseMeasure> ms = virtualCubeMapping.getReferencedMeasures();
-        for (org.eclipse.daanse.rolap.mapping.model.BaseMeasure mappingMeasure : ms) {
+        List<? extends org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BaseMeasure> ms = virtualCubeMapping.getReferencedMeasures();
+        for (org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.BaseMeasure mappingMeasure : ms) {
             measureHash.put(mappingMeasure.getName(), mappingMeasure);
             if (mappingMeasure.getMeasureGroup() != null
                     && mappingMeasure.getMeasureGroup().getPhysicalCube() != null) {
@@ -311,15 +311,15 @@ public class RolapVirtualCube extends RolapCube implements VirtualCube {
         return origMeasureList;
     }
 
-    private boolean vcHasAllCalcMembers(List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> origCalcMeasureList,
-            List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> mappingVirtualCubeCalculatedMemberList) {
+    private boolean vcHasAllCalcMembers(List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> origCalcMeasureList,
+            List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> mappingVirtualCubeCalculatedMemberList) {
         return getCalculatedMemberList()
                 .size() == (origCalcMeasureList.size() + mappingVirtualCubeCalculatedMemberList.size());
     }
 
-    protected boolean findOriginalMembers(Formula formula, List<? extends org.eclipse.daanse.rolap.mapping.model.CalculatedMember> mappingCalcMembers,
+    protected boolean findOriginalMembers(Formula formula, List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember> mappingCalcMembers,
             List<Formula> calcMembers) {
-        for (org.eclipse.daanse.rolap.mapping.model.CalculatedMember mappingCalcMember : mappingCalcMembers) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.CalculatedMember mappingCalcMember : mappingCalcMembers) {
             Hierarchy hierarchy = null;
             if (mappingCalcMember.getHierarchy() != null) {
                 hierarchy = lookupHierarchy(

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/RolapCubeDimensionTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/RolapCubeDimensionTest.java
@@ -46,11 +46,13 @@ import org.eclipse.daanse.rolap.element.RolapDimension;
 import org.eclipse.daanse.rolap.element.RolapHierarchy;
 import org.eclipse.daanse.rolap.element.RolapVirtualCube;
 import org.eclipse.daanse.rolap.element.TestPublicRolapDimension;
-import org.eclipse.daanse.rolap.mapping.model.PhysicalCube;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
 class RolapCubeDimensionTest {
 
   private RolapCubeDimension stubRolapCubeDimension(boolean virtualCube) {
@@ -61,7 +63,7 @@ class RolapCubeDimensionTest {
     doReturn(rolapDim_hierarchies).when(rolapDim).getHierarchies();
     doReturn(OlapMetaDataBase.empty()).when(rolapDim).getMetaData();
     
-    org.eclipse.daanse.rolap.mapping.model.StandardDimension cubeDim = RolapMappingFactory.eINSTANCE.createStandardDimension();
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.StandardDimension cubeDim = DimensionFactory.eINSTANCE.createStandardDimension();
     cubeDim.setName("StubCubeDimCaption");
     cubeDim.setDescription("StubCubeDimDescription");
     cubeDim.setVisible(true);
@@ -69,7 +71,7 @@ class RolapCubeDimensionTest {
     String name = "StubCubeName";
     int cubeOrdinal = 0;
     List<RolapHierarchy> hierarchyList = null;
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector dimensionConnector = RolapMappingFactory.eINSTANCE.createDimensionConnector();
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector dimensionConnector = DimensionFactory.eINSTANCE.createDimensionConnector();
     dimensionConnector.setDimension(cubeDim);
     
     return new RolapCubeDimension(
@@ -84,14 +86,14 @@ class RolapCubeDimensionTest {
   @Test
   void lookupCubeNull() {
     RolapCubeDimension rcd = stubRolapCubeDimension(false);
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector dimConnector = RolapMappingFactory.eINSTANCE.createDimensionConnector();
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector dimConnector = DimensionFactory.eINSTANCE.createDimensionConnector();
       assertThat(rcd.lookupFactCube(dimConnector, null)).isNull();
   }
 
   @Test
   void lookupCubeNotVirtual() {
     RolapCubeDimension rcd = stubRolapCubeDimension(false);
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim = RolapMappingFactory.eINSTANCE.createDimensionConnector();
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim = DimensionFactory.eINSTANCE.createDimensionConnector();
     RolapCatalog schema = mock(RolapCatalog.class);
 
       assertThat(rcd.lookupFactCube(cubeDim, schema)).isNull();
@@ -103,13 +105,13 @@ class RolapCubeDimensionTest {
     RolapCubeDimension rcd = stubRolapCubeDimension(false);
     RolapCatalog schema = mock(RolapCatalog.class);
     final String cubeName = "TheCubeName";
-    PhysicalCube cube = RolapMappingFactory.eINSTANCE.createPhysicalCube();
+    PhysicalCube cube = CubeFactory.eINSTANCE.createPhysicalCube();
     cube.setName(cubeName);
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector dimCon = RolapMappingFactory.eINSTANCE.createDimensionConnector();
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector dimCon = DimensionFactory.eINSTANCE.createDimensionConnector();
     dimCon.setPhysicalCube(cube);
 
     // explicit doReturn - just to make it evident
-    doReturn(null).when(schema).lookupCube(any(org.eclipse.daanse.rolap.mapping.model.Cube.class));
+    doReturn(null).when(schema).lookupCube(any(org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube.class));
 
       assertThat(rcd.lookupFactCube(dimCon, schema)).isNull();
     Mockito.verify(schema).lookupCube(cube);
@@ -119,9 +121,9 @@ class RolapCubeDimensionTest {
   void lookupCubeFound() {
     RolapCubeDimension rcd = stubRolapCubeDimension(false);
     final String cubeName = "TheCubeName";
-    PhysicalCube cube = RolapMappingFactory.eINSTANCE.createPhysicalCube();
+    PhysicalCube cube = CubeFactory.eINSTANCE.createPhysicalCube();
     cube.setName(cubeName);
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeCon = RolapMappingFactory.eINSTANCE.createDimensionConnector();
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeCon = DimensionFactory.eINSTANCE.createDimensionConnector();
     cubeCon.setPhysicalCube(cube);
 
     RolapCatalog schema = mock(RolapCatalog.class);

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/RolapCubeHierarchyTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/RolapCubeHierarchyTest.java
@@ -66,7 +66,7 @@ class RolapCubeHierarchyTest {
     doReturn(context).when(schemaReader).getContext();
 
 
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim = null;
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim = null;
 
     RolapHierarchy rolapHierarchy = mock(RolapHierarchy.class);
     Hierarchy rolapHierarchy_hierarchy = null;
@@ -118,7 +118,7 @@ class RolapCubeHierarchyTest {
     doReturn(context).when(schemaReader).getContext();
 
 
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim = null;
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim = null;
 
     RolapHierarchy rolapHierarchy = mock(RolapHierarchy.class);
     Hierarchy rolapHierarchy_hierarchy = null;
@@ -162,14 +162,14 @@ class RolapCubeHierarchyTest {
         mock(Connection.class);
     DataSource cubeDimension_schema_connection_DS = mock(DataSource.class);
 
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim = null;
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim = null;
 
     RolapHierarchy rolapHierarchy = mock(RolapHierarchy.class);
     Hierarchy rolapHierarchy_hierarchy = null;
     String rolapHierarchy_uniqueName = "TheDimUniqueName";
     String dimName = "DimName";
     List<? extends Level> rolapHierarchy_levels = new ArrayList<>();
-    org.eclipse.daanse.rolap.mapping.model.Query rolapHierarchy_relation = mock(org.eclipse.daanse.rolap.mapping.model.TableQuery.class);
+    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rolapHierarchy_relation = mock(org.eclipse.daanse.rolap.mapping.model.database.source.TableSource.class);
     CatalogReader schemaReader = mock(CatalogReader.class);
     Context<?> context = mock(Context.class);
     doReturn(false).when(context).getConfigValue(ConfigConstants.MEMORY_MONITOR, ConfigConstants.MEMORY_MONITOR_DEFAULT_VALUE, Boolean.class);
@@ -180,7 +180,7 @@ class RolapCubeHierarchyTest {
     int ordinal = 0;
 
     RolapCube factCube = mock(RolapCube.class);
-    org.eclipse.daanse.rolap.mapping.model.Query factCube_Fact = mock(org.eclipse.daanse.rolap.mapping.model.TableQuery.class);
+    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource factCube_Fact = mock(org.eclipse.daanse.rolap.mapping.model.database.source.TableSource.class);
     boolean factCube_Fact_equals = false;
 
       // check
@@ -223,14 +223,14 @@ class RolapCubeHierarchyTest {
     doReturn(false).when(context).getConfigValue(ConfigConstants.MEMORY_MONITOR, ConfigConstants.MEMORY_MONITOR_DEFAULT_VALUE, Boolean.class);
     doReturn(context).when(schemaReader).getContext();
 
-    org.eclipse.daanse.rolap.mapping.model.DimensionConnector cubeDim = null;
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector cubeDim = null;
 
     RolapHierarchy rolapHierarchy = mock(RolapHierarchy.class);
     Hierarchy rolapHierarchy_hierarchy = null;
     String rolapHierarchy_uniqueName = "TheDimUniqueName";
     List<? extends Level> rolapHierarchy_levels = new ArrayList<>();
-    org.eclipse.daanse.rolap.mapping.model.TableQuery rolapHierarchy_relation = mock(org.eclipse.daanse.rolap.mapping.model.TableQuery.class);
-    org.eclipse.daanse.rolap.mapping.model.PhysicalTable table = mock(org.eclipse.daanse.rolap.mapping.model.PhysicalTable.class);
+    org.eclipse.daanse.rolap.mapping.model.database.source.TableSource rolapHierarchy_relation = mock(org.eclipse.daanse.rolap.mapping.model.database.source.TableSource.class);
+    org.eclipse.daanse.cwm.model.cwm.resource.relational.Table table = mock(org.eclipse.daanse.cwm.model.cwm.resource.relational.Table.class);
     doReturn("TableName").when(table).getName();
     doReturn(table).when(rolapHierarchy_relation).getTable();
     String subName = null;
@@ -238,7 +238,7 @@ class RolapCubeHierarchyTest {
     int ordinal = 0;
 
     RolapCube factCube = mock(RolapCube.class);
-    org.eclipse.daanse.rolap.mapping.model.Query factCube_Fact = rolapHierarchy_relation;
+    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource factCube_Fact = rolapHierarchy_relation;
     boolean factCube_Fact_equals = true;
 
       // check

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/RolapDimensionTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/RolapDimensionTest.java
@@ -31,9 +31,9 @@ import org.eclipse.daanse.olap.common.SystemWideProperties;
 import org.eclipse.daanse.rolap.element.RolapCatalog;
 import org.eclipse.daanse.rolap.element.RolapCube;
 import org.eclipse.daanse.rolap.element.RolapDimension;
-import org.eclipse.daanse.rolap.mapping.model.ColumnInternalDataType;
-import org.eclipse.daanse.rolap.mapping.model.HideMemberIf;
-import org.eclipse.daanse.rolap.mapping.model.LevelDefinition;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.HideMemberIf;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelDefinition;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,28 +42,31 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
 class RolapDimensionTest {
 
   private RolapCatalog schema;
   private RolapCube cube;
-  private org.eclipse.daanse.rolap.mapping.model.Dimension xmlDimension;
-  private org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlCubeDimension;
-  private org.eclipse.daanse.rolap.mapping.model.ExplicitHierarchy hierarchy;
+  private org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension xmlDimension;
+  private org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlCubeDimension;
+  private org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy hierarchy;
 
 
     @BeforeEach void beforeEach() {
 
     schema = Mockito.mock(RolapCatalog.class);
     cube = Mockito.mock(RolapCube.class);
-    org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact = Mockito.mock(org.eclipse.daanse.rolap.mapping.model.RelationalQuery.class);
+    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact = Mockito.mock(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource.class);
 
     Mockito.when(cube.getCatalog()).thenReturn(schema);
     Mockito.when(cube.getFact()).thenReturn(fact);
 
-    xmlDimension = RolapMappingFactory.eINSTANCE.createStandardDimension();
+    xmlDimension = DimensionFactory.eINSTANCE.createStandardDimension();
 
-    hierarchy = RolapMappingFactory.eINSTANCE.createExplicitHierarchy(); 
-    org.eclipse.daanse.rolap.mapping.model.Level level = RolapMappingFactory.eINSTANCE.createLevel();
+    hierarchy = HierarchyFactory.eINSTANCE.createExplicitHierarchy(); 
+    org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level level = LevelFactory.eINSTANCE.createLevel();
     level.setVisible(true);
     level.getMemberProperties().addAll(List.of());
     level.setUniqueMembers(true);
@@ -71,7 +74,7 @@ class RolapDimensionTest {
     level.setHideMemberIf(HideMemberIf.NEVER);
     level.setType(LevelDefinition.REGULAR);
 
-    xmlCubeDimension = RolapMappingFactory.eINSTANCE.createDimensionConnector();
+    xmlCubeDimension = DimensionFactory.eINSTANCE.createDimensionConnector();
 
     xmlDimension.setName("dimensionName");
     xmlDimension.setVisible(true);
@@ -91,8 +94,8 @@ class RolapDimensionTest {
   @Disabled("disabled for CI build") //disabled for CI build
   @Test
   void hierarchyRelation() {
-	  org.eclipse.daanse.rolap.mapping.model.Query hierarchyTable = (org.eclipse.daanse.rolap.mapping.model.Query) Mockito
-            .mock(org.eclipse.daanse.rolap.mapping.model.RelationalQuery.class);
+	  org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource hierarchyTable = (org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource) Mockito
+            .mock(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource.class);
     hierarchy.setQuery(hierarchyTable);
 
     new RolapDimension(schema, cube, xmlDimension, xmlCubeDimension);

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/RolapSchemaTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/RolapSchemaTest.java
@@ -66,22 +66,22 @@ import org.eclipse.daanse.rolap.common.star.RolapStar;
 import org.eclipse.daanse.rolap.common.star.RolapStarRegistry;
 import org.eclipse.daanse.rolap.element.RolapCatalog;
 import org.eclipse.daanse.rolap.element.RolapCube;
-import org.eclipse.daanse.rolap.mapping.model.AccessCatalogGrant;
-import org.eclipse.daanse.rolap.mapping.model.AccessCubeGrant;
-import org.eclipse.daanse.rolap.mapping.model.AccessDimensionGrant;
-import org.eclipse.daanse.rolap.mapping.model.AccessHierarchyGrant;
-import org.eclipse.daanse.rolap.mapping.model.AccessMemberGrant;
-import org.eclipse.daanse.rolap.mapping.model.CatalogAccess;
-import org.eclipse.daanse.rolap.mapping.model.CubeAccess;
-import org.eclipse.daanse.rolap.mapping.model.DimensionAccess;
-import org.eclipse.daanse.rolap.mapping.model.ExplicitHierarchy;
-import org.eclipse.daanse.rolap.mapping.model.HierarchyAccess;
-import org.eclipse.daanse.rolap.mapping.model.MemberAccess;
-import org.eclipse.daanse.rolap.mapping.model.PhysicalCube;
-import org.eclipse.daanse.rolap.mapping.model.PhysicalTable;
+import org.eclipse.daanse.rolap.mapping.model.access.common.AccessCatalogGrant;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.AccessCubeGrant;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.AccessDimensionGrant;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.AccessHierarchyGrant;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.AccessMemberGrant;
+import org.eclipse.daanse.rolap.mapping.model.access.common.CatalogAccess;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.CubeAccess;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.DimensionAccess;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.HierarchyAccess;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.MemberAccess;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
-import org.eclipse.daanse.rolap.mapping.model.RollupPolicy;
-import org.eclipse.daanse.rolap.mapping.model.StandardDimension;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.RollupPolicy;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.StandardDimension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +89,12 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 
+import org.eclipse.daanse.rolap.mapping.model.access.common.CommonFactory;
+import org.eclipse.daanse.rolap.mapping.model.access.olap.OlapFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
 /**
  * @author Andrey Khayrutdinov
  */
@@ -145,8 +151,8 @@ class RolapCatalogTest {
 
     @Test
     void createUnionRoleThrowsExceptionWhenSchemaGrantsExist() {
-    	org.eclipse.daanse.rolap.mapping.model.AccessRole role = RolapMappingFactory.eINSTANCE.createAccessRole();
-    	org.eclipse.daanse.rolap.mapping.model.AccessCatalogGrant accessCatalogGrant = RolapMappingFactory.eINSTANCE.createAccessCatalogGrant();
+    	org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole role = CommonFactory.eINSTANCE.createAccessRole();
+    	org.eclipse.daanse.rolap.mapping.model.access.common.AccessCatalogGrant accessCatalogGrant = CommonFactory.eINSTANCE.createAccessCatalogGrant();
     	role.getAccessCatalogGrants().add(accessCatalogGrant);
 
         try {
@@ -162,10 +168,10 @@ class RolapCatalogTest {
     @Test
     void createUnionRoleThrowsExceptionWhenRoleNameIsUnknown() {
         final String roleName = "non-existing role name";
-        org.eclipse.daanse.rolap.mapping.model.AccessRole usage = RolapMappingFactory.eINSTANCE.createAccessRole();
+        org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole usage = CommonFactory.eINSTANCE.createAccessRole();
         usage.setName(roleName);
 
-        org.eclipse.daanse.rolap.mapping.model.AccessRole role = RolapMappingFactory.eINSTANCE.createAccessRole();
+        org.eclipse.daanse.rolap.mapping.model.access.common.AccessRole role = CommonFactory.eINSTANCE.createAccessRole();
         role.getReferencedAccessRoles().add(usage);
 
         try {
@@ -185,12 +191,12 @@ class RolapCatalogTest {
         schema = spy(schema);
         doNothing().when(schema)
             .handleCubeGrant(
-                any(RoleImpl.class), any( org.eclipse.daanse.rolap.mapping.model.AccessCubeGrant.class));
+                any(RoleImpl.class), any( org.eclipse.daanse.rolap.mapping.model.access.olap.AccessCubeGrant.class));
 
-        AccessCubeGrant cubeGrant1 = RolapMappingFactory.eINSTANCE.createAccessCubeGrant();
-        AccessCubeGrant cubeGrant2 = RolapMappingFactory.eINSTANCE.createAccessCubeGrant();
+        AccessCubeGrant cubeGrant1 = OlapFactory.eINSTANCE.createAccessCubeGrant();
+        AccessCubeGrant cubeGrant2 = OlapFactory.eINSTANCE.createAccessCubeGrant();
         
-        AccessCatalogGrant grant = RolapMappingFactory.eINSTANCE.createAccessCatalogGrant();
+        AccessCatalogGrant grant = CommonFactory.eINSTANCE.createAccessCatalogGrant();
         grant.setCatalogAccess(CatalogAccess.CUSTOM);
         grant.getCubeGrants().add(cubeGrant1);
         grant.getCubeGrants().add(cubeGrant2);
@@ -210,10 +216,10 @@ class RolapCatalogTest {
         schema = spy(schema);
         doReturn(null).when(schema).lookupCube(anyString());
 
-        PhysicalCube cube = RolapMappingFactory.eINSTANCE.createPhysicalCube();
+        PhysicalCube cube = CubeFactory.eINSTANCE.createPhysicalCube();
         cube.setName("cube");
         
-        AccessCubeGrant grant = RolapMappingFactory.eINSTANCE.createAccessCubeGrant();
+        AccessCubeGrant grant = OlapFactory.eINSTANCE.createAccessCubeGrant();
         grant.setCube(cube); 
 
         try {
@@ -242,24 +248,24 @@ class RolapCatalogTest {
 
         RolapCube cube = mockCube(schema);
         when(cube.getCatalogReader(any())).thenReturn(reader);
-        doReturn(cube).when(schema).lookupCube(any(org.eclipse.daanse.rolap.mapping.model.Cube.class));
+        doReturn(cube).when(schema).lookupCube(any(org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube.class));
 
-        StandardDimension dim = RolapMappingFactory.eINSTANCE.createStandardDimension();
+        StandardDimension dim = DimensionFactory.eINSTANCE.createStandardDimension();
         dim.setName("dimension");
 
-        AccessDimensionGrant dimensionGrant = RolapMappingFactory.eINSTANCE.createAccessDimensionGrant();
+        AccessDimensionGrant dimensionGrant = OlapFactory.eINSTANCE.createAccessDimensionGrant();
 
         dimensionGrant.setDimension(dim);
         dimensionGrant.setDimensionAccess(DimensionAccess.NONE);
 
-        PhysicalCube c = RolapMappingFactory.eINSTANCE.createPhysicalCube();
+        PhysicalCube c = CubeFactory.eINSTANCE.createPhysicalCube();
         c.setName("cube");
 
-        AccessCubeGrant grant = RolapMappingFactory.eINSTANCE.createAccessCubeGrant();
+        AccessCubeGrant grant = OlapFactory.eINSTANCE.createAccessCubeGrant();
         grant.setCube(c);
         grant.setCubeAccess(CubeAccess.CUSTOM);
         
-        AccessHierarchyGrant accessHierarchyGrant = RolapMappingFactory.eINSTANCE.createAccessHierarchyGrant();
+        AccessHierarchyGrant accessHierarchyGrant = OlapFactory.eINSTANCE.createAccessHierarchyGrant();
         
         grant.getDimensionGrants().addAll(List.of(dimensionGrant));
         grant.getHierarchyGrants().addAll(List.of(accessHierarchyGrant));
@@ -301,14 +307,14 @@ class RolapCatalogTest {
     void getOrCreateStarStarCreatedAndUsed()
         throws Exception {
       //Create the test fact
-    	PhysicalTable table = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+    	org.eclipse.daanse.cwm.model.cwm.resource.relational.Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
     	table.setName("getFactTable())");
     	
-    	org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlWhereExpression = RolapMappingFactory.eINSTANCE.createSqlStatement();
+    	org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlWhereExpression = SourceFactory.eINSTANCE.createSqlStatement();
     	sqlWhereExpression.getDialects().add("mysql");
     	sqlWhereExpression.setSql("`TableAlias`.`promotion_id` = 112");
     	
-    	org.eclipse.daanse.rolap.mapping.model.TableQuery fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+    	org.eclipse.daanse.rolap.mapping.model.database.source.TableSource fact = SourceFactory.eINSTANCE.createTableSource();
     	fact.setTable(table);
     	fact.setAlias("TableAlias");
     	fact.setSqlWhereExpression(sqlWhereExpression);
@@ -339,14 +345,14 @@ class RolapCatalogTest {
     void getStarFromRegistryByStarKey() throws Exception {
       //Create the test fact
     	
-    	PhysicalTable table = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+    	org.eclipse.daanse.cwm.model.cwm.resource.relational.Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
     	table.setName(getFactTable());
     	
-    	org.eclipse.daanse.rolap.mapping.model.SqlStatement sqlWhereExpression = RolapMappingFactory.eINSTANCE.createSqlStatement();
+    	org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sqlWhereExpression = SourceFactory.eINSTANCE.createSqlStatement();
     	sqlWhereExpression.getDialects().add("mysql");
     	sqlWhereExpression.setSql("`TableAlias`.`promotion_id` = 112");
 
-    	org.eclipse.daanse.rolap.mapping.model.TableQuery fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+    	org.eclipse.daanse.rolap.mapping.model.database.source.TableSource fact = SourceFactory.eINSTANCE.createTableSource();
     	fact.setTable(table);
     	fact.setAlias("TableAlias");
     	fact.setSqlWhereExpression(sqlWhereExpression);
@@ -366,10 +372,10 @@ class RolapCatalogTest {
     void getStarFromRegistryByFactTableName() throws Exception {
       //Create the test fact
     	
-    	PhysicalTable table = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+    	org.eclipse.daanse.cwm.model.cwm.resource.relational.Table table = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
     	table.setName("getFactTable())");
     	
-    	org.eclipse.daanse.rolap.mapping.model.TableQuery fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+    	org.eclipse.daanse.rolap.mapping.model.database.source.TableSource fact = SourceFactory.eINSTANCE.createTableSource();
     	fact.setTable(table);
     	fact.setAlias("TableAlias");
 
@@ -384,7 +390,7 @@ class RolapCatalogTest {
     }
 
     private static RolapStarRegistry getStarRegistryLinkedToRolapCatalogSpy(
-        RolapCatalog schemaSpy, org.eclipse.daanse.rolap.mapping.model.RelationalQuery fact) throws Exception
+        RolapCatalog schemaSpy, org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource fact) throws Exception
     {
       //the rolap star registry is linked to the origin rolap schema,
       //not to the schemaSpy
@@ -443,12 +449,12 @@ class RolapCatalogTest {
         RolapCube cube = mockCube(schema);
         org.eclipse.daanse.olap.access.RoleImpl role = new org.eclipse.daanse.olap.access.RoleImpl();
 
-        AccessMemberGrant memberGrant = RolapMappingFactory.eINSTANCE.createAccessMemberGrant();
+        AccessMemberGrant memberGrant = OlapFactory.eINSTANCE.createAccessMemberGrant();
         memberGrant.setMember("member");
         memberGrant.setMemberAccess(MemberAccess.ALL);
 
-        ExplicitHierarchy h = RolapMappingFactory.eINSTANCE.createExplicitHierarchy();
-        AccessHierarchyGrant grant = RolapMappingFactory.eINSTANCE.createAccessHierarchyGrant();
+        ExplicitHierarchy h = HierarchyFactory.eINSTANCE.createExplicitHierarchy();
+        AccessHierarchyGrant grant = OlapFactory.eINSTANCE.createAccessHierarchyGrant();
         grant.setHierarchyAccess(HierarchyAccess.CUSTOM);
         grant.setRollupPolicy(RollupPolicy.FULL);
         grant.setHierarchy(h);
@@ -458,7 +464,7 @@ class RolapCatalogTest {
         Hierarchy hierarchy = mock(Hierarchy.class);
         when(hierarchy.getLevels()).thenAnswer(setupDummyListAnswer(level));
         when(level.getHierarchy()).thenReturn(hierarchy);
-        when(cube.lookupHierarchy(any(org.eclipse.daanse.rolap.mapping.model.Hierarchy.class))).thenReturn(hierarchy);
+        when(cube.lookupHierarchy(any(org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy.class))).thenReturn(hierarchy);
         Dimension dimension = mock(Dimension.class);
         when(hierarchy.getDimension()).thenReturn(dimension);
 

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/RolapStarTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/RolapStarTest.java
@@ -34,8 +34,8 @@ import org.eclipse.daanse.rolap.common.star.RolapStar;
 import org.eclipse.daanse.rolap.common.star.RolapStar.Column;
 import org.eclipse.daanse.rolap.element.RolapCatalog;
 import org.eclipse.daanse.rolap.element.RolapCube;
-import org.eclipse.daanse.rolap.mapping.model.Query;
-import org.eclipse.daanse.rolap.mapping.model.RelationalQuery;
+import org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource;
+import org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,13 +49,13 @@ class RolapStarTest {
         public RolapStarForTests(
             final RolapCatalog schema,
             final Context<?> context,
-            final RelationalQuery fact)
+            final RelationalSource fact)
         {
             super(schema, context, fact);
         }
 
-        public Query cloneRelationForTests(
-            RelationalQuery rel,
+        public RelationalSource cloneRelationForTests(
+            RelationalSource rel,
             String possibleName)
         {
             return cloneRelation(rel, possibleName);

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/RolapUtilTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/RolapUtilTest.java
@@ -33,12 +33,13 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import org.eclipse.daanse.rolap.common.star.RolapStarRegistry;
-import org.eclipse.daanse.rolap.mapping.model.PhysicalTable;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
 import org.eclipse.daanse.rolap.mapping.model.RolapMappingFactory;
-import org.eclipse.daanse.rolap.mapping.model.SqlStatement;
-import org.eclipse.daanse.rolap.mapping.model.TableQuery;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement;
+import org.eclipse.daanse.rolap.mapping.model.database.source.TableSource;
 import org.junit.jupiter.api.Test;
 
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
 class RolapUtilTest {
 
   private static final String FILTER_QUERY =
@@ -47,17 +48,17 @@ class RolapUtilTest {
   private static final String TABLE_ALIAS = "TableAlias";
   private static final String RELATION_ALIAS = "RelationAlias";
   private static final String FACT_NAME = "order_fact";
-  private TableQuery fact;
+  private TableSource fact;
 
   @Test
   void makeRolapStarKeyUnmodifiable() throws Exception {
       assertThatThrownBy(() -> {
-          PhysicalTable t = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+          org.eclipse.daanse.cwm.model.cwm.resource.relational.Table t = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
           t.setName("getFactTable())");
-          SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+          SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
           sqlStatement.getDialects().add("mysql");
           sqlStatement.setSql("`TableAlias`.`promotion_id` = 112");
-          fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+          fact = SourceFactory.eINSTANCE.createTableSource();
           fact.setTable(t);
           fact.setAlias("TableAlias");
           fact.setSqlWhereExpression(sqlStatement);
@@ -70,13 +71,13 @@ class RolapUtilTest {
   @Test
   void makeRolapStarKeyByFactTableName() throws Exception {
     //fact = SchemaUtil.parse(getFactTableWithSQLFilter(), TableQueryMappingImpl.class);
-      PhysicalTable t = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+      org.eclipse.daanse.cwm.model.cwm.resource.relational.Table t = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
       t.setName("getFactTable())");
-      SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+      SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
       sqlStatement.getDialects().add("mysql");
       sqlStatement.setSql("`TableAlias`.`promotion_id` = 112");
       
-      fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+      fact = SourceFactory.eINSTANCE.createTableSource();
       fact.setTable(t);
       fact.setAlias("TableAlias");
       fact.setSqlWhereExpression(sqlStatement);
@@ -90,13 +91,13 @@ class RolapUtilTest {
   @Test
   void makeRolapStarKeyFactTableWithSQLFilter() throws Exception {
     //fact = SchemaUtil.parse(getFactTableWithSQLFilter(), TableQueryMappingImpl.class);
-      PhysicalTable t = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+      org.eclipse.daanse.cwm.model.cwm.resource.relational.Table t = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
       t.setName("getFactTable())");
-      SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+      SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
       sqlStatement.getDialects().add("mysql");
       sqlStatement.setSql("`TableAlias`.`promotion_id` = 112");
       
-      fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+      fact = SourceFactory.eINSTANCE.createTableSource();
       fact.setTable(t);
       fact.setAlias("TableAlias");
       fact.setSqlWhereExpression(sqlStatement);
@@ -113,12 +114,12 @@ class RolapUtilTest {
   void makeRolapStarKeyFactTableWithEmptyFilter()
       throws Exception {
     //fact = SchemaUtil.parse(getFactTableWithEmptySQLFilter(), TableQueryMappingImpl.class);
-      PhysicalTable t = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+      org.eclipse.daanse.cwm.model.cwm.resource.relational.Table t = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
       t.setName("getFactTable())");
-      SqlStatement sqlStatement = RolapMappingFactory.eINSTANCE.createSqlStatement();
+      SqlStatement sqlStatement = SourceFactory.eINSTANCE.createSqlStatement();
       sqlStatement.getDialects().add("mysql");
       
-      fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+      fact = SourceFactory.eINSTANCE.createTableSource();
       fact.setTable(t);
       fact.setAlias("TableAlias");
       fact.setSqlWhereExpression(sqlStatement);
@@ -134,10 +135,10 @@ class RolapUtilTest {
   void makeRolapStarKeyFactTableWithoutSQLFilter()
       throws Exception {
     //fact = SchemaUtil.parse(getFactTableWithoutSQLFilter(), TableQueryMappingImpl.class);
-      PhysicalTable t = RolapMappingFactory.eINSTANCE.createPhysicalTable();
+      org.eclipse.daanse.cwm.model.cwm.resource.relational.Table t = org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory.eINSTANCE.createTable();
       t.setName("getFactTable())");
       
-      fact = RolapMappingFactory.eINSTANCE.createTableQuery();
+      fact = SourceFactory.eINSTANCE.createTableSource();
       fact.setTable(t);
       fact.setAlias("TableAlias");
 
@@ -156,8 +157,8 @@ class RolapUtilTest {
       assertThat(polapStarKey.getFirst()).isEqualTo(RELATION_ALIAS);
   }
 
-  private static org.eclipse.daanse.rolap.mapping.model.RelationalQuery getFactRelationMock() throws Exception {
-	  org.eclipse.daanse.rolap.mapping.model.RelationalQuery factMock = mock(org.eclipse.daanse.rolap.mapping.model.InlineTableQuery.class);
+  private static org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getFactRelationMock() throws Exception {
+	  org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource factMock = mock(org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource.class);
     when(factMock.getAlias()).thenReturn(RELATION_ALIAS);
     return factMock;
   }

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/SqlTupleReaderTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/SqlTupleReaderTest.java
@@ -80,12 +80,12 @@ class SqlTupleReaderTest {
     RolapColumn expression =  mock(org.eclipse.daanse.rolap.element.RolapColumn.class);
     RolapCubeLevel levelIter = mock( RolapCubeLevel.class, Answers.RETURNS_MOCKS );
     RolapProperty rolapProperty = mock( TestPublicRolapProperty.class, Answers.RETURNS_MOCKS );
-    org.eclipse.daanse.rolap.mapping.model.Query queryMapping = mock( org.eclipse.daanse.rolap.mapping.model.Query.class, Answers.RETURNS_MOCKS );
+    org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource queryMapping = mock( org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource.class, Answers.RETURNS_MOCKS );
     String propertyName = "property_1";
     Dialect dialect = mock( Dialect.class );
     when(dialect.getDialectName()).thenReturn( "generic" );
     when(dialect.quoteIdentifier(any(String.class), any(String.class))).thenReturn( "generic" );
-    org.eclipse.daanse.rolap.mapping.model.SqlStatement sql = mock(org.eclipse.daanse.rolap.mapping.model.SqlStatement.class );
+    org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement sql = mock(org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement.class );
     when(sql.getDialects()).thenAnswer(setupDummyListAnswer("generic"));
     when(sql.getSql()).thenReturn( "SQL" );
     when(expression.getSqls()).thenAnswer(setupDummyListAnswer(sql));

--- a/core/src/test/java/org/eclipse/daanse/rolap/element/TestPublicRolapDimension.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/element/TestPublicRolapDimension.java
@@ -20,8 +20,8 @@ package org.eclipse.daanse.rolap.element;
 
 public class TestPublicRolapDimension extends RolapDimension{
 
-	TestPublicRolapDimension(RolapCatalog schema, RolapCube cube, org.eclipse.daanse.rolap.mapping.model.Dimension xmlDimension,
-			org.eclipse.daanse.rolap.mapping.model.DimensionConnector xmlCubeDimension) {
+	TestPublicRolapDimension(RolapCatalog schema, RolapCube cube, org.eclipse.daanse.rolap.mapping.model.olap.dimension.Dimension xmlDimension,
+			org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector xmlCubeDimension) {
 		super(schema, cube, xmlDimension, xmlCubeDimension);
 	}
 

--- a/core/src/test/java/org/eclipse/daanse/rolap/integration/BasicContextServiceTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/integration/BasicContextServiceTest.java
@@ -57,6 +57,7 @@ import org.osgi.test.junit5.context.BundleContextExtension;
 
 import aQute.bnd.annotation.spi.ServiceProvider;
 
+import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 @ExtendWith(BundleContextExtension.class)
 @ExtendWith(ConfigurationExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -92,7 +93,7 @@ class BasicContextServiceTest {
     @Mock
     MdxParserProvider mdxParserProvider;
 
-    org.eclipse.daanse.rolap.mapping.model.Catalog catalogMapping=RolapMappingFactory.eINSTANCE.createCatalog();
+    org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalogMapping=CatalogFactory.eINSTANCE.createCatalog();
 
     @Mock
     FunctionService functionService;

--- a/core/test.bndrun
+++ b/core/test.bndrun
@@ -65,6 +65,9 @@
 	org.apache.aries.spifly.dynamic.bundle;version='[1.3.7,1.3.8)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
+	org.eclipse.daanse.cwm.model;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.util;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.jdbc.db.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.jdbc.db.dialect.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.mdx.model.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.mdx.parser.api;version='[0.0.1,0.0.2)',\
@@ -80,7 +83,7 @@
 	org.eclipse.emf.common;version='[2.44.0,2.44.1)',\
 	org.eclipse.emf.ecore;version='[2.41.0,2.41.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.39.0,2.39.1)',\
-	org.eclipse.fennec.emf.osgi.component;version='[1.0.0,1.0.1)',\
+	org.eclipse.fennec.emf.osgi.component;version='[0.1.1,0.1.2)',\
 	org.mockito.junit-jupiter;version='[4.9.0,4.9.1)',\
 	org.mockito.mockito-core;version='[4.9.0,4.9.1)',\
 	org.objectweb.asm;version='[9.9.0,9.9.1)',\

--- a/documentation/common/src/main/java/org/eclipse/daanse/rolap/documentation/common/impl/MarkdownDocumentationProvider.java
+++ b/documentation/common/src/main/java/org/eclipse/daanse/rolap/documentation/common/impl/MarkdownDocumentationProvider.java
@@ -77,6 +77,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.eclipse.daanse.cwm.util.resource.relational.ColumnSets;
 import org.osgi.service.metatype.annotations.Designate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,7 +183,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         writeCubeMatrixDiagram(writer, context, context.getCatalogMapping());
     }
 
-    private void writeCubeMatrixDiagram(FileWriter writer, Context context, org.eclipse.daanse.rolap.mapping.model.Catalog catalog) {
+    private void writeCubeMatrixDiagram(FileWriter writer, Context context, org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog) {
         try {
             String catalogName = catalog.getName();
             writer.write("### Cube Matrix for ");
@@ -201,8 +202,8 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
                     quadrant-4 Wide
                     """);
             writer.write(ENTER);
-            for (org.eclipse.daanse.rolap.mapping.model.Cube cube : catalog.getCubes()) {
-                if (cube instanceof org.eclipse.daanse.rolap.mapping.model.PhysicalCube c) {
+            for (org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cube : catalog.getCubes()) {
+                if (cube instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube c) {
                     String cubeName = prepare(c.getName());
                     double x = getLevelsCount(catalog, c) / MAX_LEVEL;
                     double y = getFactCount(c) / MAX_ROW;
@@ -234,21 +235,23 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return x < 1 ? "%,.4f".formatted(x) : "1";
     }
 
-    private long getFactCount(org.eclipse.daanse.rolap.mapping.model.PhysicalCube c) {
+    private long getFactCount(org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube c) {
         long result = 0l;
         try {
-        	org.eclipse.daanse.rolap.mapping.model.Query relation = c.getQuery();
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mt) {
+        	org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation = c.getQuery();
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mt) {
                 TableReference tableReference = new TableReferenceR(mt.getTable().getName());
                 return getTableCardinality(tableReference);
             }
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery it) {
-                result = it.getTable().getRows() == null ? 0l : it.getTable().getRows().size();
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource it) {
+                result = (it.getTable() == null || it.getTable().getExtent() == null) ? 0L
+                    : it.getTable().getExtent().getOwnedElement().stream()
+                        .filter(org.eclipse.daanse.cwm.model.cwm.resource.relational.Row.class::isInstance).count();
             }
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery) {
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource) {
                 return 0L;
             }
-            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery mj) {
+            if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource mj) {
                 Optional<String> tableName = getFactTableName(mj);
                 if (tableName.isPresent()) {
                     TableReference tableReference = new TableReferenceR(tableName.get());
@@ -285,24 +288,24 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return maxNonUnique;
     }
 
-    private int getLevelsCount(org.eclipse.daanse.rolap.mapping.model.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.PhysicalCube c) {
+    private int getLevelsCount(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube c) {
         int res = 0;
-        for (org.eclipse.daanse.rolap.mapping.model.DimensionConnector d : c.getDimensionConnectors()) {
+        for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector d : c.getDimensionConnectors()) {
             res = res + getLevelsCount1(catalog, d);
         }
         return res;
     }
 
-    private int getLevelsCount1(org.eclipse.daanse.rolap.mapping.model.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.DimensionConnector d) {
+    private int getLevelsCount1(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector d) {
         int res = 0;
         if (d.getDimension() != null && d.getDimension().getHierarchies() != null) {
-            for (org.eclipse.daanse.rolap.mapping.model.Hierarchy h : d.getDimension().getHierarchies()) {
-                if (h instanceof org.eclipse.daanse.rolap.mapping.model.ExplicitHierarchy eh) {
+            for (org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy h : d.getDimension().getHierarchies()) {
+                if (h instanceof org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy eh) {
                     if (eh.getLevels() != null) {
                         res = res + eh.getLevels().size();
                     }
                 }
-                if (h instanceof org.eclipse.daanse.rolap.mapping.model.ParentChildHierarchy pch) {
+                if (h instanceof org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ParentChildHierarchy pch) {
                     if (pch.getLevel() != null) {
                         res = res + 1;
                     }
@@ -332,17 +335,17 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
 
     private List<String> schemaTablesConnections(RolapContext context, List<String> missedTableNames) {
         List<String> result = new ArrayList<>();
-        org.eclipse.daanse.rolap.mapping.model.Catalog catalog = context.getCatalogMapping();
+        org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog = context.getCatalogMapping();
         result.addAll(catalog.getCubes().stream()
                 .flatMap(c -> cubeTablesConnections(catalog, c, missedTableNames).stream()).toList());
         return result;
     }
 
-    private List<String> cubeTablesConnections(org.eclipse.daanse.rolap.mapping.model.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.Cube cube,
+    private List<String> cubeTablesConnections(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.olap.cube.Cube cube,
             List<String> missedTableNames) {
 
         List<String> result = new ArrayList<>();
-        if (cube instanceof org.eclipse.daanse.rolap.mapping.model.PhysicalCube c) {
+        if (cube instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube c) {
             Optional<String> optionalFactTable = getFactTableName(c.getQuery());
             if (optionalFactTable.isPresent()) {
                 result.addAll(getFactTableConnections(c.getQuery(), missedTableNames));
@@ -404,7 +407,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         int i = 0;
         String dName = new StringBuilder("d").append(cubeIndex).append(dimensionIndex).toString();
         for (Hierarchy h : hList) {
-        	org.eclipse.daanse.rolap.mapping.model.Column primaryKey = ((RolapHierarchy) h).getHierarchyMapping().getPrimaryKey();
+        	org.eclipse.daanse.cwm.model.cwm.resource.relational.Column primaryKey = ((RolapHierarchy) h).getHierarchyMapping().getPrimaryKey();
             result.add(connection1(cubeName, dName, foreignKey, getColumnName(primaryKey)));
             for (org.eclipse.daanse.olap.api.element.Level l : catalogReader.getHierarchyLevels(h)) {
                 result.add(connection1(dName,
@@ -416,8 +419,8 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return result;
     }
 
-    private List<String> dimensionsTablesConnections(org.eclipse.daanse.rolap.mapping.model.Catalog catalog,
-            List<? extends org.eclipse.daanse.rolap.mapping.model.DimensionConnector> dimensionUsageOrDimensions, String fact,
+    private List<String> dimensionsTablesConnections(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog,
+            List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector> dimensionUsageOrDimensions, String fact,
             List<String> missedTableNames) {
         if (dimensionUsageOrDimensions != null) {
             return dimensionUsageOrDimensions.stream()
@@ -426,7 +429,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return List.of();
     }
 
-    private List<String> dimensionTablesConnections(org.eclipse.daanse.rolap.mapping.model.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.DimensionConnector d, String fact,
+    private List<String> dimensionTablesConnections(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector d, String fact,
             List<String> missedTableNames) {
 
         return hierarchiesTablesConnections(catalog, d.getDimension().getHierarchies(), fact,
@@ -434,8 +437,8 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
 
     }
 
-    private List<String> hierarchiesTablesConnections(org.eclipse.daanse.rolap.mapping.model.Catalog catalog,
-            List<? extends org.eclipse.daanse.rolap.mapping.model.Hierarchy> hierarchies, String fact, String foreignKey,
+    private List<String> hierarchiesTablesConnections(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog,
+            List<? extends org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy> hierarchies, String fact, String foreignKey,
             List<String> missedTableNames) {
         if (hierarchies != null) {
             return hierarchies.stream()
@@ -445,10 +448,10 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return List.of();
     }
 
-    private List<String> hierarchyTablesConnections(org.eclipse.daanse.rolap.mapping.model.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.Hierarchy h, String fact,
+    private List<String> hierarchyTablesConnections(org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog, org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.Hierarchy h, String fact,
             String foreignKey, List<String> missedTableNames) {
         List<String> result = new ArrayList<>();
-        String primaryKeyTable = getTableName(h.getPrimaryKey().getTable());
+        String primaryKeyTable = getTableName(((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) h.getPrimaryKey().getOwner()));
         if (primaryKeyTable == null) {
             Optional<String> optionalTable = getFactTableName(h.getQuery());
             if (optionalTable.isPresent()) {
@@ -467,7 +470,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return result;
     }
 
-    private String getColumnName(org.eclipse.daanse.rolap.mapping.model.Column column) {
+    private String getColumnName(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
         if (column != null) {
             return column.getName();
         }
@@ -495,7 +498,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
 
     }
 
-    private void writeSchemaVerifyer(FileWriter writer, org.eclipse.daanse.rolap.mapping.model.Catalog catalog, RolapContext context) {
+    private void writeSchemaVerifyer(FileWriter writer, org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog, RolapContext context) {
         try {
             List<VerificationResult> verifyResult = new ArrayList<>();
             List<VerificationResult> dbVerifyResult = new ArrayList<>();
@@ -604,7 +607,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         }
     }
 
-    private void writeSchemaAsXML(FileWriter writer, org.eclipse.daanse.rolap.mapping.model.Catalog catalog) {
+    private void writeSchemaAsXML(FileWriter writer, org.eclipse.daanse.rolap.mapping.model.catalog.Catalog catalog) {
         try {
             String catalogName = catalog.getName();
             writer.write("### Schema ");
@@ -681,7 +684,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
 
     private void writeCube(FileWriter writer, Cube cube, CatalogReader catalogReader) {
         try {
-            if (cube instanceof org.eclipse.daanse.rolap.mapping.model.PhysicalCube pc) {
+            if (cube instanceof org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube pc) {
                 String description = cube.getDescription() != null ? cube.getDescription() : EMPTY_STRING;
                 String name = cube.getName() != null ? cube.getName() : "";
                 String table = getTable(pc.getQuery());
@@ -814,10 +817,10 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
 
     private void writeAggregationSection(FileWriter writer, CatalogReader catalogReader, Cube cube,
             RolapContext context) {
-        Optional<org.eclipse.daanse.rolap.mapping.model.TableQuery> tableQuery = getFactTableQuery((RolapCube) cube);
+        Optional<org.eclipse.daanse.rolap.mapping.model.database.source.TableSource> tableQuery = getFactTableQuery((RolapCube) cube);
         if (tableQuery.isPresent() && tableQuery.get().getAggregationTables() != null) {
             try (Connection connection = context.getDataSource().getConnection()) {
-                List<? extends org.eclipse.daanse.rolap.mapping.model.AggregationTable> aggregationTables = tableQuery.get().getAggregationTables();
+                List<? extends org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable> aggregationTables = tableQuery.get().getAggregationTables();
                 DatabaseMetaData databaseMetaData = connection.getMetaData();
                 List<? extends DatabaseSchema> dbschemas = catalogReader.getDatabaseSchemas();
                 SchemaReference schemaReference = new SchemaReferenceR(connection.getSchema());
@@ -833,7 +836,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
                         ```mermaid
                            erDiagram
                            """);
-                org.eclipse.daanse.rolap.mapping.model.Table factTable = tableQuery.get().getTable();
+                org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet factTable = tableQuery.get().getTable();
                 Optional<TableReference> oTableReference = tables.stream()
                         .filter(t -> (t.table() != null && t.table().name().equals(factTable.getName())))
                         .map(t -> t.table()).findAny();
@@ -844,10 +847,10 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
                 } else {
                     writeTablesDiagram(writer, factTable);
                 }
-                for (org.eclipse.daanse.rolap.mapping.model.AggregationTable aggregationTable : aggregationTables) {
-                    if (aggregationTable instanceof org.eclipse.daanse.rolap.mapping.model.AggregationName aggregationName
+                for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationTable aggregationTable : aggregationTables) {
+                    if (aggregationTable instanceof org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName aggregationName
                             && aggregationName.getName() != null) {
-                    	org.eclipse.daanse.rolap.mapping.model.Table aggTable = aggregationName.getName();
+                    	org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet aggTable = aggregationName.getName();
                         oTableReference = tables.stream()
                                 .filter(t -> (t.table() != null && t.table().name().equals(factTable.getName())))
                                 .map(t -> t.table()).findAny();
@@ -867,7 +870,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
                     writer.write(tableFlag);
                     writer.write("\"{");
                     writer.write(ENTER);
-                    for (org.eclipse.daanse.rolap.mapping.model.AggregationExclude aggregationExclude : tableQuery.get().getAggregationExcludes()) {
+                    for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationExclude aggregationExclude : tableQuery.get().getAggregationExcludes()) {
                         writer.write("x ");
                         writer.write(aggregationExclude.getName());
                         writer.write(ENTER);
@@ -890,31 +893,31 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         }
     }
 
-    private Collection<? extends String> aggregationConnections(org.eclipse.daanse.rolap.mapping.model.AggregationName aggregationName,
+    private Collection<? extends String> aggregationConnections(org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationName aggregationName,
             List<String> mt) {
         List<String> tablesConnections = new ArrayList<>();
         if (aggregationName.getAggregationForeignKeys() != null) {
-            for (org.eclipse.daanse.rolap.mapping.model.AggregationForeignKey aggregationForeignKey : aggregationName.getAggregationForeignKeys()) {
+            for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationForeignKey aggregationForeignKey : aggregationName.getAggregationForeignKeys()) {
                 if (aggregationForeignKey.getFactColumn() != null
-                        && aggregationForeignKey.getFactColumn().getTable() != null
+                        && ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationForeignKey.getFactColumn().getOwner()) != null
                         && aggregationForeignKey.getAggregationColumn() != null
-                        && aggregationForeignKey.getAggregationColumn().getTable() != null) {
-                    tablesConnections.add(connection1(aggregationForeignKey.getFactColumn().getTable().getName(),
-                            aggregationForeignKey.getAggregationColumn().getTable().getName(),
+                        && ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationForeignKey.getAggregationColumn().getOwner()) != null) {
+                    tablesConnections.add(connection1(((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationForeignKey.getFactColumn().getOwner()).getName(),
+                            ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationForeignKey.getAggregationColumn().getOwner()).getName(),
                             aggregationForeignKey.getFactColumn().getName(),
                             aggregationForeignKey.getAggregationColumn().getName()));
                 }
             }
         }
         if (aggregationName.getAggregationMeasureFactCounts() != null) {
-            for (org.eclipse.daanse.rolap.mapping.model.AggregationMeasureFactCount aggregationMeasureFactCount : aggregationName
+            for (org.eclipse.daanse.rolap.mapping.model.database.aggregation.AggregationMeasureFactCount aggregationMeasureFactCount : aggregationName
                     .getAggregationMeasureFactCounts()) {
                 if (aggregationMeasureFactCount.getFactColumn() != null
-                        && aggregationMeasureFactCount.getFactColumn().getTable() != null
+                        && ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationMeasureFactCount.getFactColumn().getOwner()) != null
                         && aggregationMeasureFactCount.getColumn() != null
-                        && aggregationMeasureFactCount.getColumn().getTable() != null) {
-                    tablesConnections.add(connection1(aggregationMeasureFactCount.getFactColumn().getTable().getName(),
-                            aggregationMeasureFactCount.getColumn().getTable().getName(),
+                        && ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationMeasureFactCount.getColumn().getOwner()) != null) {
+                    tablesConnections.add(connection1(((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationMeasureFactCount.getFactColumn().getOwner()).getName(),
+                            ((org.eclipse.daanse.cwm.model.cwm.resource.relational.Table) aggregationMeasureFactCount.getColumn().getOwner()).getName(),
                             aggregationMeasureFactCount.getFactColumn().getName(),
                             aggregationMeasureFactCount.getColumn().getName()));
                 }
@@ -923,8 +926,8 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return tablesConnections;
     }
 
-    private Optional<org.eclipse.daanse.rolap.mapping.model.TableQuery> getFactTableQuery(RolapCube cube) {
-        if (cube.getFact() != null && cube.getFact() instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery tableQuery) {
+    private Optional<org.eclipse.daanse.rolap.mapping.model.database.source.TableSource> getFactTableQuery(RolapCube cube) {
+        if (cube.getFact() != null && cube.getFact() instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource tableQuery) {
             return Optional.of(tableQuery);
         }
         return Optional.empty();
@@ -1110,17 +1113,17 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         }
     }
 
-    private Optional<String> getFactTableName(org.eclipse.daanse.rolap.mapping.model.Query relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mt) {
+    private Optional<String> getFactTableName(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mt) {
             return Optional.ofNullable(getTableName(mt.getTable()));
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery it) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource it) {
             return Optional.ofNullable(it.getAlias());
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery mv) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource mv) {
             return Optional.ofNullable(mv.getAlias());
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery mj) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource mj) {
             if (mj.getLeft() != null && mj.getLeft().getQuery() != null) {
                 return getFactTableName(mj.getLeft().getQuery());
             }
@@ -1128,24 +1131,24 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return Optional.empty();
     }
 
-    private String getTableName(org.eclipse.daanse.rolap.mapping.model.Table table) {
+    private String getTableName(org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table) {
         if (table != null) {
             return table.getName();
         }
         return null;
     }
 
-    private List<String> getFactTableConnections(org.eclipse.daanse.rolap.mapping.model.Query relation, List<String> missedTableNames) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mt) {
+    private List<String> getFactTableConnections(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation, List<String> missedTableNames) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mt) {
             return List.of();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery it) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource it) {
             return List.of();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery mv) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource mv) {
             return List.of();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery mj) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource mj) {
             if (mj.getLeft() != null && mj.getRight() != null && mj.getLeft().getQuery() != null
                     && mj.getRight().getQuery() != null) {
                 ArrayList<String> res = new ArrayList<>();
@@ -1176,11 +1179,11 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return "\"" + t1 + "\" ||--|| \"" + t2 + "\" : \"" + k1 + k2 + "\"";
     }
 
-    private String getFirstTable(org.eclipse.daanse.rolap.mapping.model.Query relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mt) {
+    private String getFirstTable(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mt) {
             return getTableName(mt.getTable());
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery mj) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource mj) {
             if (mj.getLeft() != null && mj.getLeft().getQuery() != null) {
                 return getFirstTable(mj.getLeft().getQuery());
             }
@@ -1188,23 +1191,23 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return null;
     }
 
-    private String getTable(org.eclipse.daanse.rolap.mapping.model.Query relation) {
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.TableQuery mt) {
+    private String getTable(org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource mt) {
             return getTableName(mt.getTable());
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.InlineTableQuery) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.InlineTableSource) {
             // InlineTableQuery not yet supported for table extraction
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.SqlSelectQuery mv) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource mv) {
             StringBuilder sb = new StringBuilder();
-            if (mv.getSql() != null && mv.getSql().getSqlStatements() != null) {
-                mv.getSql().getSqlStatements().stream()
+            if (mv.getSql() != null && mv.getSql().getDialectStatements() != null) {
+                mv.getSql().getDialectStatements().stream()
                         .filter(s -> s.getDialects().stream().anyMatch(d -> "generic".equals(d))).findFirst()
                         .ifPresent(s -> sb.append(s.getSql()));
             }
             return sb.toString();
         }
-        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.JoinQuery mj) {
+        if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource mj) {
             StringBuilder sb = new StringBuilder();
             if (mj.getLeft() != null && mj.getRight() != null && mj.getLeft().getQuery() != null
                     && mj.getRight().getQuery() != null) {
@@ -1273,9 +1276,9 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         return Optional.empty();
     }
 
-    private void writeTablesDiagram(FileWriter writer, org.eclipse.daanse.rolap.mapping.model.Table table) {
+    private void writeTablesDiagram(FileWriter writer, org.eclipse.daanse.cwm.model.cwm.resource.relational.NamedColumnSet table) {
         try {
-            List<? extends org.eclipse.daanse.rolap.mapping.model.Column> columnList = table.getColumns();
+            List<? extends org.eclipse.daanse.cwm.model.cwm.resource.relational.Column> columnList = ColumnSets.columns(table);
             String name = table.getName();
             String tableFlag = NEGATIVE_FLAG;
             writer.write("\"");
@@ -1284,9 +1287,9 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
             writer.write("\"{");
             writer.write(ENTER);
             if (columnList != null) {
-                for (org.eclipse.daanse.rolap.mapping.model.Column c : columnList) {
+                for (org.eclipse.daanse.cwm.model.cwm.resource.relational.Column c : columnList) {
                     String columnName = c.getName();
-                    String type = c.getType() != null ? c.getType().getLiteral() : "";
+                    String type = c.getType() != null ? c.getType().getName() : "";
                     String flag = NEGATIVE_FLAG;
                     writer.write(type);
                     writer.write(" ");
@@ -1456,13 +1459,13 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
         }
     }
 
-    private String getSize(org.eclipse.daanse.rolap.mapping.model.Column column) {
-        if (column.getColumnSize() != null && column.getColumnSize() > 0) {
+    private String getSize(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
+        if ((column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst ? _sst.getCharacterMaximumLength() : null) != null && (column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst ? _sst.getCharacterMaximumLength() : null) > 0) {
             StringBuilder r = new StringBuilder();
             r.append("(");
-            r.append(column.getColumnSize());
-            if (column.getDecimalDigits() != null && column.getDecimalDigits() > 0) {
-                r.append(".").append(column.getDecimalDigits());
+            r.append((column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst ? _sst.getCharacterMaximumLength() : null));
+            if ((column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst2 ? _sst2.getNumericScale() : null) != null && (column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst2 ? _sst2.getNumericScale() : null) > 0) {
+                r.append(".").append((column.getType() instanceof org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType _sst2 ? _sst2.getNumericScale() : null));
             }
             r.append(") ");
             return r.toString();
@@ -1503,10 +1506,10 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
                 : "not null ";
     }
 
-    private String getNullable(org.eclipse.daanse.rolap.mapping.model.Column column) {
+    private String getNullable(org.eclipse.daanse.cwm.model.cwm.resource.relational.Column column) {
 
-        if (column.getNullable() != null) {
-            return column.getNullable() ? "is null " : "not null ";
+        if ((column.getIsNullable() != null ? column.getIsNullable().getValue() == 1 : null) != null) {
+            return (column.getIsNullable() != null ? column.getIsNullable().getValue() == 1 : null) ? "is null " : "not null ";
         } else {
             return "is null ";
         }


### PR DESCRIPTION
- Repoint mapping types to database.source / database.relational / olap.* / catalog.* packages (RelationalQuery -> RelationalSource, TableQuery -> TableSource, InlineTableQuery -> InlineTableSource, SqlSelectQuery -> SqlSelectSource, SqlView -> DialectSqlView, Hierarchy/Level/Cube/Catalog moved under olap.*/catalog.*).

- RolapUtil.convertInlineTableToRelation: read inline-table rows via CWM RowSet/Row/DataSlot using cwm.util ColumnSets/RowSets/Rows.

- LevelUtil/HierarchyUsage: resolve column owners through Columns.owner(); accept ColumnSet (Table/View/InlineTable) instead

of NamedColumnSet/Table casts. New hierarchy-aware overloads in LevelUtil and RolapHierarchy.findAliasForOwner so shared physical tables resolve to per-hierarchy aliases.

- RolapCube.getStar(): drop `instanceof RolapPhysicalCube` gate; key on `getFact() != null` so any cube with a fact gets a star (fixes NPE cluster after schema-cache flush).

- core/pom.xml: add org.eclipse.daanse.cwm.util dependency.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Daanse
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
