### PR TITLE
rolap: fix javadoc errors from stale links after the SqlQuery removal

### DIFF
--- a/core/src/main/java/org/eclipse/daanse/rolap/common/SqlTupleReader.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/SqlTupleReader.java
@@ -134,7 +134,7 @@ import org.slf4j.LoggerFactory;
  *
  * When reading members from a single level, then the constraint is not
  * required to join the fact table in
- * {@link TupleConstraint#addLevelConstraintOps}
+ * {@code TupleConstraint.addLevelConstraintOps}
  * although it may do so to restrict
  * the result. Also it is permitted to cache the parent/children from all
  * members in MemberCache, so
@@ -145,7 +145,7 @@ import org.slf4j.LoggerFactory;
  * then we can not store the parent/child pairs in the MemberCache and
  * {@link TupleConstraint#getMemberChildrenConstraint(RolapMember)}
  * must return null. Also
- * {@link TupleConstraint#addConstraintOps}
+ * {@code TupleConstraint.addConstraintOps}
  * is required to join the fact table for the levels table.
  *
  *

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/agg/OrPredicate.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/agg/OrPredicate.java
@@ -88,31 +88,6 @@ public class OrPredicate extends ListPredicate {
         return new AndPredicate(list);
     }
 
-    /**
-     * Checks whether a predicate can be translated using an IN list, and groups
-     * predicates based on how many columns can be translated using IN list. If
-     * none of the columns can be made part of IN, the entire predicate will be
-     * translated using AND/OR. This method identifies all the columns that can
-     * be part of IN and and categorizes this predicate based on number of
-     * column values to use in the IN list.
-     *
-     * @param predicate predicate to analyze
-     * @param dialect Query
-     * @param predicateMap the map containing predicates analyzed so far
-     */
-
-    /**
-     * Translates a list of predicates over the same set of columns into sql
-     * using IN list where possible.
-     *
-     * @param dialect Query
-     * @param buf buffer to build sql
-     * @param inListRhsBitKey which column positions are included in
-     *     the IN predicate; the non included positions corresponde to
-     *     columns that are nulls
-     * @param predicateList the list of predicates to translate.
-     */
-
     @Override
 	protected String getOp() {
         return "or";

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/constraint/SlicerAnalyzer.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/constraint/SlicerAnalyzer.java
@@ -101,7 +101,7 @@ public class SlicerAnalyzer {
    * Gets a map of Expression to the set of sliced members associated with each expression.
    *
    * This map is used by addContextConstraint() to get the set of slicer members associated with each column in the cell
-   * request's constrained columns array, {@link CellRequest#getConstrainedColumns}
+   * request's constrained columns array, {@link org.eclipse.daanse.rolap.common.agg.CellRequest#getConstrainedColumns()}
    */
   // public: reused by SqlContextConstraint.toContribution and by
   // RolapNativeFilter.FilterConstraint.isSupported (the IN-list-limit check needs the SAME

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/sql/MemberKeyConstraint.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/sql/MemberKeyConstraint.java
@@ -89,7 +89,7 @@ public class MemberKeyConstraint
     /**
      * The generic-builder counterpart of {@code addConstraint}: each {@code column = value} (or
      * {@code IS NULL}) as a builder {@code WHERE} predicate, with no fact join (a dimension-only key
-     * restriction). Mirrors {@link LevelConstraintGenerator#constrainKeyValue}.
+     * restriction). Mirrors {@code LevelConstraintGenerator.constrainKeyValue}.
      */
     @Override
     public java.util.Optional<ConstraintContribution> toContribution(RolapCube baseCube, AggStar aggStar) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/sql/MemberListCrossJoinArg.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/sql/MemberListCrossJoinArg.java
@@ -230,12 +230,12 @@ public class MemberListCrossJoinArg implements CrossJoinArg {
     }
 
     /** Whether this arg excludes (rather than includes) its members — mirrors the {@code exclude} flag the
-     *  {@link #addConstraint} passes to {@code MemberConstraintWriter.addMemberConstraint}. */
+     *  {@code addConstraint} passes to {@code MemberConstraintWriter.addMemberConstraint}. */
     public boolean isExclude() {
         return exclude;
     }
 
-    /** Whether calculated members are restricted — the {@code restrictMemberTypes} flag {@link #addConstraint}
+    /** Whether calculated members are restricted — the {@code restrictMemberTypes} flag {@code addConstraint}
      *  passes to {@code MemberConstraintWriter.addMemberConstraint}. */
     public boolean isRestrictMemberTypes() {
         return restrictMemberTypes;

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/sqlbuild/MemberSqlMapper.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/sqlbuild/MemberSqlMapper.java
@@ -309,8 +309,8 @@ public final class MemberSqlMapper {
     }
 
     /**
-     * Comma-join fallback of the fact-join {@link #childMemberSql(RolapLevel, boolean, Optional, List,
-     * boolean)} overload for shapes with no resolvable dimension→fact edge: FROM lists the relation,
+     * Comma-join fallback of the fact-join {@link #childMemberSql(RolapLevel, boolean, Optional, List)}
+     * overload for shapes with no resolvable dimension→fact edge: FROM lists the relation,
      * the fact and the context tables as comma items, every star join is a WHERE conjunct. Guarded
      * use only — the ANSI form is the primary shape, so this is reached only via the guard's fallback.
      */
@@ -353,7 +353,7 @@ public final class MemberSqlMapper {
     }
 
     /**
-     * As the fact-join {@link #childMemberSql(RolapLevel, boolean, Optional, List, boolean)} overload but
+     * As the fact-join {@link #childMemberSql(RolapLevel, boolean, Optional, List)} overload but
      * with the context constraint's per-column {@code (table, predicate)} pairs so the WHERE is
      * interleaved exactly like the {@code addMemberConstraint + addLevelConstraint} sequence:
      * <ol>

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/sqlbuild/TupleSqlMapper.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/sqlbuild/TupleSqlMapper.java
@@ -1390,15 +1390,16 @@ public final class TupleSqlMapper {
      * table, root down to target, each added to GROUP BY (every collapsed column is grouped
      * unconditionally) and ordered ASC nulls-last (the standalone
      * {@code WhichSelect.ONLY} read this path is restricted to). {@code where} (the agg-substituted
-     * context — {@link SqlContextConstraint#levelMembersAggWhere}) is split into per-conjunct
+     * context — {@link org.eclipse.daanse.rolap.common.constraint.SqlContextConstraint#levelMembersAggWhere}) is split into per-conjunct
      * WHERE clauses (a nested {@code And} stays grouped).
      * <p>
      * {@code nativeHaving} (a native Filter measure condition) and {@code nativeOrder} (a native
      * TopCount/BottomCount measure order) are carried the SAME way {@link #buildLevelSelect} does — the
      * HAVING after the GROUP BY, the measure order projected and ORDERed BEFORE the level ordering — but
      * both already agg-substituted by the constraint's agg counterparts
-     * ({@link SqlContextConstraint#levelMembersAggHaving} /
-     * {@link SqlContextConstraint#levelMembersAggOrder}), since the aggStar read has no base-star
+     * ({@link org.eclipse.daanse.rolap.common.constraint.SqlContextConstraint#levelMembersAggHaving} /
+     * {@link org.eclipse.daanse.rolap.common.constraint.SqlContextConstraint#levelMembersAggOrder}),
+     * since the aggStar read has no base-star
      * contribution to resolve them through. A plain (non-native) context constraint passes both empty and
      * the body is identical to the pure-projection shape.
      */


### PR DESCRIPTION
The javadoc build failed with 14 errors, all dangling references left behind by the dialect-free statement builder migration:

- TupleConstraint.addLevelConstraintOps / addConstraintOps and LevelConstraintGenerator.constrainKeyValue no longer exist; the MemberListCrossJoinArg accessors document a caller that was renamed. Demote those {@link}s to {@code}.
- MemberSqlMapper#childMemberSql was linked with a signature that no overload has; point at the fact-join (RolapLevel, boolean, Optional, List) one.
- SqlContextConstraint and CellRequest are not imported by TupleSqlMapper and SlicerAnalyzer; qualify the links.
- OrPredicate carried two orphaned doc blocks for deleted IN-list helpers. The trailing one bound to getOp(), so its @params resolved against a no-arg method. Remove both.
