### PR TITLE
refactor!: adopt the sentinel-free null semantics in the load path

### DIFF
--- a/core/src/main/java/org/eclipse/daanse/rolap/aggregator/SumAggregator.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/aggregator/SumAggregator.java
@@ -19,6 +19,7 @@ import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.exception.OlapRuntimeException;
+import org.eclipse.daanse.olap.calc.base.CompensatedSum;
 import org.eclipse.daanse.olap.fun.FunUtil;
 
 public class SumAggregator extends AbstractAggregator {
@@ -54,30 +55,27 @@ public class SumAggregator extends AbstractAggregator {
         assert !rawData.isEmpty();
         switch (datatype) {
         case INTEGER:
-            int sumInt = Integer.MIN_VALUE;
+            Integer sumInt = null;
             for (Object data : rawData) {
                 if (data != null) {
-                    if (sumInt == Integer.MIN_VALUE) {
-                        sumInt = 0;
-                    }
                     if (data instanceof Double) {
                         data = ((Double) data).intValue();
                     }
-                    sumInt += (Integer) data;
+                    sumInt = sumInt == null ? (Integer) data : sumInt + (Integer) data;
                 }
             }
-            return sumInt == Integer.MIN_VALUE ? null : sumInt;
+            return sumInt;
         case NUMERIC:
-            double sumDouble = Double.MIN_VALUE;
+            CompensatedSum sumDouble = null;
             for (Object data : rawData) {
                 if (data != null) {
-                    if (sumDouble == Double.MIN_VALUE) {
-                        sumDouble = 0;
+                    if (sumDouble == null) {
+                        sumDouble = new CompensatedSum();
                     }
-                    sumDouble += ((Number) data).doubleValue();
+                    sumDouble.add(((Number) data).doubleValue());
                 }
             }
-            return sumDouble == Double.MIN_VALUE ? null : sumDouble;
+            return sumDouble == null ? null : sumDouble.value();
         default:
             throw new OlapRuntimeException(new StringBuilder("Aggregator ").append(name)
                     .append(" does not support datatype").append(datatype.getValue()).toString());

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/RolapAggregationManager.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/RolapAggregationManager.java
@@ -40,6 +40,8 @@ import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.element.OlapElement;
 import org.eclipse.daanse.olap.api.evaluator.Evaluator;
 import org.eclipse.daanse.olap.api.exception.OlapRuntimeException;
+import org.eclipse.daanse.olap.api.result.CellValue;
+import org.eclipse.daanse.olap.api.result.NullValue;
 import org.eclipse.daanse.olap.common.Util;
 import org.eclipse.daanse.olap.key.BitKey;
 import org.eclipse.daanse.rolap.api.element.RolapMember;
@@ -86,7 +88,7 @@ public abstract class RolapAggregationManager {
 
     /**
      * Creates the RolapAggregationManager.
-     */
+ */
     protected RolapAggregationManager() {
     }
 
@@ -100,7 +102,7 @@ public abstract class RolapAggregationManager {
      *
      * @param members Set of members which constrain the cell
      * @return Cell request, or null if the requst is unsatisfiable
-     */
+ */
     public static CellRequest makeRequest(final Member[] members) {
         return makeCellRequest(
             members, false, false, null, null, null,
@@ -123,7 +125,7 @@ public abstract class RolapAggregationManager {
      *
      * @param cube              Cube
      * @return Cell request, or null if the requst is unsatisfiable
-     */
+ */
     public static DrillThroughCellRequest makeDrillThroughRequest(
         final Member[] members,
         final boolean extendedContext,
@@ -148,7 +150,7 @@ public abstract class RolapAggregationManager {
      * Returns a List of OlapElement consisting of elements present on
      * the base cube in context.  If drillthrough is happening on a virtual
      * cube this may exclude non-conforming dimensions, for example.
-     */
+ */
     private static List<OlapElement> getApplicableReturnClauseMembers(
         RolapCube cube, Member[] members,
         List<OlapElement> returnClauseMembers, boolean extendedContext)
@@ -228,7 +230,7 @@ public abstract class RolapAggregationManager {
      *
      * @param evaluator the cell specified by the evaluator context
      * @return Cell request, or null if the requst is unsatisfiable
-     */
+ */
     public static CellRequest makeRequest(
         RolapEvaluator evaluator)
     {
@@ -261,7 +263,7 @@ public abstract class RolapAggregationManager {
      * aggregationLists.  Uses this to add the predicate (and its string
      * representation) to the cell request.
      * Returns false if any predicate results in an unsatisfiable request.
-     */
+ */
     private static boolean applyCompoundPredicates(
         RolapEvaluator evaluator, CellRequest request)
     {
@@ -291,7 +293,7 @@ public abstract class RolapAggregationManager {
      * If the aggregationList is the slicer, will attempt to retrieve the
      * pre-built slicer predicate info from the evaluator.  This avoids the
      * overhead of building the slicer predicates for every cell request.
-     */
+ */
     private static CompoundPredicateInfo getCompoundPredicateInfo(
         RolapEvaluator evaluator,
         RolapStoredMeasure measure,
@@ -451,7 +453,7 @@ public abstract class RolapAggregationManager {
      * @param member Member to constraint
      * @param baseCube base cube if virtual
      * @param request Cell request
-     */
+ */
     private static void addNonConstrainingColumns(
         final RolapCubeMember member,
         final RolapCube baseCube,
@@ -579,7 +581,7 @@ public abstract class RolapAggregationManager {
      * can be created from the aggregationList. It is possible that only part
      * of the aggregationList can be applied, which still leads to a (partial)
      * constraint that is represented by the compoundGroupMap.
-     */
+ */
     private static boolean makeCompoundGroup(
         int starColumnCount,
         RolapCube baseCube,
@@ -745,7 +747,7 @@ public abstract class RolapAggregationManager {
      * @param compoundGroupMap Map from dimensionality to groups
      * @param baseCube base cube if virtual
      * @return compound predicate for a tuple or a member
-     */
+ */
     private static StarPredicate makeCompoundPredicate(
         Map<BitKey, List<RolapCubeMember[]>> compoundGroupMap,
         RolapCube baseCube)
@@ -824,8 +826,9 @@ public abstract class RolapAggregationManager {
      * @param request Cell request
      *  request != null and !request.isUnsatisfiable()
      * @return Cell value, or null if cell is not in any aggregation in cache,
-     *   or {@link Util#nullValue} if cell's value is null
-     */
+     *   or {@link org.eclipse.daanse.olap.api.result.NullValue#INSTANCE} if
+     *   cell's value is null
+ */
     public abstract Object getCellFromCache(CellRequest request);
 
     public abstract Object getCellFromCache(
@@ -842,7 +845,7 @@ public abstract class RolapAggregationManager {
      * that could not be represented by the CellRequest, or
      * null if no additional predicate is necessary.
      * @return SQL statement
-     */
+ */
     public abstract String getDrillThroughSql(
         DrillThroughCellRequest request,
         StarPredicate starPredicateSlicer,
@@ -943,18 +946,23 @@ public abstract class RolapAggregationManager {
 
     /**
      * Returns a {@link org.eclipse.daanse.rolap.common.result.CellReader} which reads cells from cache.
-     */
+ */
     public CellReader getCacheCellReader() {
         return new CellReader() {
             // implement CellReader
             @Override
-			public Object get(RolapEvaluator evaluator) {
+			public CellValue get(RolapEvaluator evaluator) {
                 CellRequest request = makeRequest(evaluator);
                 if (request == null || request.isUnsatisfiable()) {
                     // request out of bounds
-                    return Util.nullValue;
+                    return NullValue.INSTANCE;
                 }
-                return getCellFromCache(request);
+                final Object o = getCellFromCache(request);
+                // This reader never lies: a cell that is in no aggregation
+                // is treated as an evaluated NULL. The probe API keeps the
+                // object convention (raw value / NullValue.INSTANCE / null);
+                // the CellValue boundary starts at this reader.
+                return toCellValue(o, NullValue.INSTANCE);
             }
 
             @Override
@@ -973,13 +981,32 @@ public abstract class RolapAggregationManager {
      * Creates a {@link PinSet}.
      *
      * @return a new PinSet
-     */
+ */
     public abstract PinSet createPinSet();
+
+    /**
+     * Bridges the object convention of the cache probe API (raw value,
+     * {@link NullValue#INSTANCE} for a stored NULL, Java {@code null} for
+     * "not in cache") into the sealed {@link CellValue} protocol of the
+     * {@link org.eclipse.daanse.rolap.common.result.CellReader} chain.
+     *
+     * @param o          cell value from the probe API
+     * @param whenAbsent state to report when the cache has no answer
+ */
+    public static CellValue toCellValue(Object o, CellValue whenAbsent) {
+        if (o == null) {
+            return whenAbsent;
+        }
+        if (o instanceof CellValue cv) {
+            return cv;
+        }
+        return CellValue.fromLegacyValue(o);
+    }
 
     /**
      * A set of segments which are pinned (prevented from garbage collection)
      * for a short duration as a result of a cache inquiry.
-     */
+ */
     public interface PinSet {
     }
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/agg/AggregationManager.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/agg/AggregationManager.java
@@ -79,7 +79,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
 
     /**
      * Creates the AggregationManager.
-     */
+ */
     public AggregationManager(RolapContext context) {
         this.context = context;
         this.cacheMgr = new SegmentCacheManager(context);
@@ -89,7 +89,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
      * Returns the logger.
      *
      * @return Logger
-     */
+ */
     public final Logger getLogger() {
         return LOGGER;
     }
@@ -107,7 +107,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
      * @param groupingSetsCollector grouping sets collector
      * @param segmentFutures List of futures into which each statement will
      *     place a list of the segments it has loaded, when it completes
-     */
+ */
     public static void loadAggregation(
         SegmentCacheManager cacheMgr,
         int cellRequestCount,
@@ -137,7 +137,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
      * @param connection Server whose cache to control
      * @param pw Print writer, for tracing
      * @return CacheControl API
-     */
+ */
     @Override
     public CacheControl getCacheControl(
         Connection connection,
@@ -245,7 +245,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
      *
      * @return A pair consisting of a SQL statement and a list of suggested
      *     types of columns
-     */
+ */
     public static RenderedSql generateSql(
         GroupingSetsList groupingSetsList,
         List<StarPredicate> compoundPredicateList, boolean useAggregates)
@@ -363,7 +363,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
      * @param rollup Out parameter, is set to true if the aggregate is not
      *   an exact match
      * @return An aggregate, or null if none is suitable.
-     */
+ */
     public static AggStar findAgg(
         RolapStar star,
         final BitKey levelBitKey,
@@ -503,7 +503,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
 
     /**
      * Sets the bits for parent columns.
-     */
+ */
     private static BitKey expandLevelBitKey(
         RolapStar star, BitKey levelBitKey)
     {
@@ -544,7 +544,7 @@ public class AggregationManager extends RolapAggregationManager implements OlapA
     /**
      * Implementation of {@link org.eclipse.daanse.rolap.common.RolapAggregationManager.PinSet}
      * using a {@link HashSet}.
-     */
+ */
     public static class PinSetImpl
         extends HashSet<Segment>
         implements RolapAggregationManager.PinSet

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/agg/SegmentLoader.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/agg/SegmentLoader.java
@@ -58,6 +58,7 @@ import org.eclipse.daanse.olap.api.execution.Execution;
 import org.eclipse.daanse.olap.api.execution.Execution.Purpose;
 import org.eclipse.daanse.olap.api.execution.ExecutionContext;
 import org.eclipse.daanse.olap.api.execution.ExecutionMetadata;
+import org.eclipse.daanse.olap.api.result.NullValue;
 import org.eclipse.daanse.olap.common.ConfigConstants;
 import org.eclipse.daanse.olap.common.SystemWideProperties;
 import org.eclipse.daanse.olap.common.Util;
@@ -693,7 +694,7 @@ public class SegmentLoader {
           case STRING:
             Object o = rawRows.getObject( columnIndex + 1 );
             if ( o == null ) {
-              o = Util.nullValue; // convert to placeholder
+              o = NullValue.INSTANCE; // convert to placeholder
             } else if ( numeric[i] ) {
               if ( o instanceof Double ) {
                 // nothing to do

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/agg/SegmentWithData.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/agg/SegmentWithData.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.api.result.NullValue;
 import org.eclipse.daanse.olap.key.BitKey;
 import org.eclipse.daanse.olap.key.CellKey;
 import org.eclipse.daanse.rolap.common.star.RolapStar;
@@ -47,7 +48,7 @@ public class SegmentWithData extends Segment {
     /**
      * An array of axes, one for each constraining column, containing the values
      * returned for that constraining column.
-     */
+ */
     final SegmentAxis[] axes;
 
     /**
@@ -73,7 +74,7 @@ public class SegmentWithData extends Segment {
      * for a given thread, any read access to data which comes after
      * dataGate.await() (or, by extension,
      * waitUntilLoaded will be threadsafe.
-     */
+ */
     private final SegmentDataset data;
 
     /**
@@ -81,7 +82,7 @@ public class SegmentWithData extends Segment {
      *
      * @param segment Segment (without data)
      * @param data Data set
-     */
+ */
     public SegmentWithData(
         Segment segment,
         SegmentDataset data,
@@ -110,7 +111,7 @@ public class SegmentWithData extends Segment {
      * @param predicates List of axes; each is a constraint plus a list of
      *     values.
      * @param excludedRegions List of regions which are not in this segment.
-     */
+ */
     private SegmentWithData(
         RolapStar star,
         BitKey constrainedColumnsBitKey,
@@ -158,17 +159,15 @@ public class SegmentWithData extends Segment {
      *
      * Returns
      *
-     * {@link org.eclipse.daanse.olap.common.Util#nullValue} if the cell value
-     * is null (because no fact table rows met those criteria);
+     * {@link org.eclipse.daanse.olap.api.result.NullValue#INSTANCE} if the
+     * cell value is null (because no fact table rows met those criteria) or
+     * a NaN aggregate;
      *
      * null if the value is not supposed to be in this segment
      * (because one or more of the keys do not pass the axis criteria);
      *
      * the data value otherwise
-     *
-     *
-     *
-     */
+ */
     public Object getCellValue(Object[] keys) {
         assert keys.length == axes.length;
         int missed = 0;
@@ -197,15 +196,15 @@ public class SegmentWithData extends Segment {
         if (missed > 0) {
             // the value should be in this segment, but isn't, because one
             // or more of its keys does have any values
-            return Util.nullValue;
+            return NullValue.INSTANCE;
         } else {
             Object o = data.getObject(cellKey);
             if (o == null) {
-                o = Util.nullValue;
+                o = NullValue.INSTANCE;
             } else if (o instanceof Double d && Double.isNaN(d)) {
                 // NaN aggregate = undefined 0/0 (e.g. avg over zero facts).
                 // Present as empty, matching NULL from division-by-zero.
-                o = Util.nullValue;
+                o = NullValue.INSTANCE;
             }
             return o;
         }
@@ -214,7 +213,7 @@ public class SegmentWithData extends Segment {
     /**
      * Returns whether the given set of key values will be in this segment
      * when it finishes loading.
-     */
+ */
     boolean wouldContain(Object[] keys) {
         Util.assertTrue(keys.length == axes.length);
         for (int i = 0; i < keys.length; i++) {
@@ -236,7 +235,7 @@ public class SegmentWithData extends Segment {
      * regions will be counted twice.
      *
      * @return Number of cells in this Segment
-     */
+ */
     public int getCellCount() {
         int cellCount = 1;
         for (SegmentAxis axis : axes) {
@@ -261,7 +260,7 @@ public class SegmentWithData extends Segment {
      * @param bestPredicate
      * @param excludedRegions List of regions to exclude from segment
      * @return Segment containing a subset of the values
-     */
+ */
     SegmentWithData createSubSegment(
         BitSet[] axisKeepBitSets,
         int bestColumn,
@@ -371,7 +370,7 @@ public class SegmentWithData extends Segment {
      * it is assumed to be invariant.
      *
      * @return The data reference
-     */
+ */
     public final SegmentDataset getData() {
         return data;
     }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/evaluator/RolapEvaluator.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/evaluator/RolapEvaluator.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.daanse.olap.calc.base.NullSemantics;
 import org.eclipse.daanse.olap.api.cache.ExpCacheDescriptor;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.calc.compiler.ParameterSlot;
@@ -56,6 +57,11 @@ import org.eclipse.daanse.olap.api.execution.Statement;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.query.component.Expression;
 import org.eclipse.daanse.olap.api.query.component.Query;
+import org.eclipse.daanse.olap.api.result.CellValue;
+import org.eclipse.daanse.olap.api.result.ErrorValue;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.api.result.NullValue;
+import org.eclipse.daanse.olap.api.result.ObjectValue;
 import org.eclipse.daanse.olap.calc.base.type.tuplebase.DelegatingTupleList;
 import org.eclipse.daanse.olap.common.ConfigConstants;
 import org.eclipse.daanse.olap.common.StandardProperty;
@@ -121,7 +127,7 @@ public class RolapEvaluator implements Evaluator {
 
   /**
    * Dummy value to represent null results in the expression cache.
-   */
+ */
   private static final Object nullResult = new Object();
     public static final String NULL_MEMBER_IN = "null member in ";
 
@@ -144,7 +150,7 @@ public class RolapEvaluator implements Evaluator {
   /**
    * List of lists of tuples or members, rarely used, but overrides the ordinary dimensional context if set when a cell
    * value comes to be evaluated.
-   */
+ */
   protected final List<List<List<Member>>> aggregationLists;
 
   private CompoundPredicateInfo slicerPredicateInfo;
@@ -166,7 +172,7 @@ public class RolapEvaluator implements Evaluator {
    * Set of expressions actively being expanded. Prevents infinite cycle of expansions.
    *
    * @return Mutable set of expressions being expanded
-   */
+ */
   public Set<Expression> getActiveNativeExpansions() {
     return root.activeNativeExpansions;
   }
@@ -182,7 +188,7 @@ public class RolapEvaluator implements Evaluator {
 
   /**
    * States of the finite state machine for determining the max solve order for the "scoped" behavior.
-   */
+ */
   private enum ScopedMaxSolveOrderFinderState {
     START, AGG_SCOPE, CUBE_SCOPE, QUERY_SCOPE
   }
@@ -196,7 +202,7 @@ public class RolapEvaluator implements Evaluator {
    *          Parent evaluator, not null
    * @param aggregationList
    *          List of tuples to add to aggregation context, or null
-   */
+ */
   protected RolapEvaluator( RolapEvaluatorRoot root, RolapEvaluator parent, List<List<Member>> aggregationList ) {
     this.iterationLength = 1;
     this.root = root;
@@ -254,7 +260,7 @@ public class RolapEvaluator implements Evaluator {
    *
    * @param root
    *          Shared context between this evaluator and its children
-   */
+ */
   public RolapEvaluator( RolapEvaluatorRoot root ) {
     this.iterationLength = 1;
     this.root = root;
@@ -287,7 +293,7 @@ public class RolapEvaluator implements Evaluator {
 
   /**
    * Creates an evaluator.
-   */
+ */
   public static Evaluator create( Statement statement ) {
     final RolapEvaluatorRoot root = new RolapEvaluatorRoot( statement );
     return new RolapEvaluator( root );
@@ -339,7 +345,7 @@ public RolapEvaluatorRoot getRoot() {
 public boolean currentIsEmpty() {
     // If a cell evaluates to null, it is always deemed empty.
     Object o = evaluateCurrent();
-    if ( o == Util.nullValue || o == null ) {
+    if ( NullSemantics.isNull( o ) ) {
       return true;
     }
     final RolapCube measureCube = getMeasureCube();
@@ -478,7 +484,7 @@ public final RolapEvaluator push() {
    * Returns true so that can conveniently be called from 'assert'.
    *
    * @return true
-   */
+ */
   private boolean addChecksumStateCommand() {
     // assume that caller has checked that command array is large enough
     commands[commandCount++] = checksumState();
@@ -491,7 +497,7 @@ public final RolapEvaluator push() {
    *
    * @param aggregationList
    *          List of tuples to add to aggregation context, or null
-   */
+ */
   protected RolapEvaluator pushClone(List<List<Member>> aggregationList ) {
     root.execution.checkCancelOrTimeout();
     return new RolapEvaluator( root, this, aggregationList );
@@ -511,7 +517,7 @@ public final Evaluator pushAggregation( List<List<Member>> list ) {
 
   /**
    * Returns true if the other object is a {@link RolapEvaluator} with identical context.
-   */
+ */
   @Override
 public final boolean equals( Object obj ) {
     if ( !( obj instanceof RolapEvaluator that ) ) {
@@ -534,7 +540,7 @@ public final int hashCode() {
    *          members in slicer
    * @param membersByHierarchy
    *          members in slicer by hierarchy
-   */
+ */
   public final void setSlicerContext( List<Member> members, Map<Hierarchy, Set<Member>> membersByHierarchy ) {
     for ( Member member : members ) {
       setContext( member );
@@ -547,7 +553,7 @@ public final int hashCode() {
    * Return the list of slicer members in the current evaluator context.
    *
    * @return slicerMembers
-   */
+ */
   @Override
   public final List<Member> getSlicerMembers() {
     return slicerMembers;
@@ -563,7 +569,7 @@ public final int hashCode() {
    *
    * @param tuples
    *          slicer
-   */
+ */
   public final void setSlicerTuples( TupleList tuples ) {
     slicerTuples = tuples;
     if ( tuples != null ) {
@@ -578,7 +584,7 @@ public final int hashCode() {
 
   /**
    * Return the list of compound slicer tuples
-   */
+ */
   public final TupleList getSlicerTuples() {
     return slicerTuples;
   }
@@ -602,7 +608,7 @@ public final int hashCode() {
    *          if this is a virtual cube, remove the unrelated tuples from the slicer.
    *
    * @return optimized slicer tuple list
-   */
+ */
   public final TupleList getOptimizedSlicerTuples( RolapCube baseCube ) {
     // removes members in the tuple list that are no longer compound.
     // for each member in the tuple, see if the evaluator is still set to
@@ -738,7 +744,7 @@ public final void setContext( Member member, boolean safe ) {
    * @param ordinal
    *          Hierarchy ordinal
    * @return Whether there is a member with the given hierarchy ordinal on the stack
-   */
+ */
   private boolean exists( int ordinal ) {
     for ( int i = commandCount - 1;; ) {
       final Command command = (Command) commands[i];
@@ -818,7 +824,7 @@ public final RolapMember getContext( Hierarchy hierarchy ) {
    * @param hierarchy
    *          Hierarchy
    * @return current member
-   */
+ */
   public final RolapMember getContext( RolapHierarchy hierarchy ) {
     return currentMembers[hierarchy.getOrdinalInCube()];
   }
@@ -831,11 +837,17 @@ public final Object evaluateCurrent() {
     RolapCalculation maxSolveMember;
     switch ( calculationCount ) {
       case 0:
-        final Object o = cellReader.get( this );
-        if ( o == Util.nullValue ) {
-          return null;
-        }
-        return o;
+        // Seam A: unwrap the CellValue state delivered by the cell/cache
+        // layer into the calc-layer conventions (MDX NULL is Java null,
+        // NotLoaded propagates as the marker object, an evaluation error
+        // is represented by its Throwable).
+        final CellValue cv = cellReader.get( this );
+        return switch ( cv ) {
+          case NullValue v -> null;
+          case NotLoaded n -> n;
+          case ErrorValue e -> e.cause();
+          case ObjectValue ov -> ov.value();
+        };
 
       case 1:
         maxSolveMember = calculations[0];
@@ -856,9 +868,6 @@ public final Object evaluateCurrent() {
       o = calc.evaluate( this );
     } finally {
       restore( savepoint );
-    }
-    if ( o == Util.nullValue ) {
-      return null;
     }
     return o;
   }
@@ -891,7 +900,7 @@ public final Object evaluateCurrent() {
    * members can share the same {@link Calc} object.
    *
    * @return Calculated member currently being expanded
-   */
+ */
   public Member getExpanding() {
     return expandingMember;
   }
@@ -903,7 +912,7 @@ public final Object evaluateCurrent() {
    *          Evaluator
    * @throws org.eclipse.daanse.olap.fun.MondrianEvaluationException
    *           if there is a loop
-   */
+ */
   private static void checkRecursion( RolapEvaluator eval, int c ) {
     RolapMember[] members = eval.currentMembers.clone();
 
@@ -1029,7 +1038,7 @@ public final Object getProperty( String name, Object defaultValue ) {
    * context, and therefore different cells may have different format strings.
    *
    *  return != null
-   */
+ */
   @Override
 public final String getFormatString() {
     final Expression formatExp = (Expression) getProperty( StandardProperty.FORMAT_EXP_PARSED.getName(), null );
@@ -1060,9 +1069,6 @@ public final Locale getConnectionLocale() {
 
   @Override
 public final String format( Object o ) {
-    if ( o == Util.nullValue ) {
-      o = null;
-    }
     if ( o instanceof Throwable ) {
       return "#ERR: " + o.toString();
     }
@@ -1072,9 +1078,6 @@ public final String format( Object o ) {
 
   @Override
 public final String format( Object o, String formatString ) {
-    if ( o == Util.nullValue ) {
-      o = null;
-    }
     if ( o instanceof Throwable ) {
       return "#ERR: " + o.toString();
     }
@@ -1085,7 +1088,7 @@ public final String format( Object o, String formatString ) {
   /**
    * Creates a key which uniquely identifes an expression and its context. The context includes members of dimensions
    * which the expression is dependent upon.
-   */
+ */
   private Object getExpResultCacheKey( ExpCacheDescriptor descriptor ) {
     boolean includeAggregationList = false;
     if ( aggregationLists != null && !aggregationLists.isEmpty() ) {
@@ -1220,7 +1223,7 @@ public final Object getParameterValue( ParameterSlot slot ) {
    *
    * 
    * No special consideration is given to the aggregate function.
-   */
+ */
   private RolapCalculation getAbsoluteMaxSolveOrder() {
     // Find member with the highest solve order.
     RolapCalculation maxSolveMember = calculations[0];
@@ -1244,7 +1247,7 @@ public final Object getParameterValue( ParameterSlot slot ) {
    * 
    * The aggregate function is always applied to base members; i.e. as if SOLVE_ORDER was defined to be the lowest value
    * in a given evaluation in a SSAS2000 sense.
-   */
+ */
   private RolapCalculation getScopedMaxSolveOrder() {
     // Finite state machine that determines the member with the highest
     // solve order.
@@ -1315,7 +1318,7 @@ public final Object getParameterValue( ParameterSlot slot ) {
    * @param calc2
    *          Second calculated member or tuple
    * @return Whether calc1 expands before calc2
-   */
+ */
   private boolean expandsBefore( RolapCalculation calc1, RolapCalculation calc2 ) {
     final int solveOrder1 = calc1.getSolveOrder();
     final int solveOrder2 = calc2.getSolveOrder();
@@ -1402,7 +1405,7 @@ public final void setEvalAxes( boolean evalAxes ) {
    * Checks if unrelated dimensions to the measure in the current context should be ignored.
    *
    * @return boolean
-   */
+ */
   private enum Command {
     SET_CONTEXT( 2 ) {
       @Override

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/result/CellReader.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/result/CellReader.java
@@ -29,23 +29,26 @@
 
 package org.eclipse.daanse.rolap.common.result;
 
-import org.eclipse.daanse.olap.common.Util;
+import org.eclipse.daanse.olap.api.result.CellValue;
 import org.eclipse.daanse.rolap.common.evaluator.RolapEvaluator;
 
 /**
  * A CellReader finds the cell value for the current context
  * held by evaluator.
  *
- * It returns:
- * null if the source is unable to evaluate the cell (for
- *   example, AggregatingCellReader does not have the cell
- *   in its cache). This value should only be returned if the caller is
- *   expecting it.
- * {@link Util#nullValue} if the cell evaluates to null
- * if the cell evaluates to an
- *   error
- * an Object representing a value (often a {@link Double} or a {@link
- *   java.math.BigDecimal}), otherwise
+ * It returns a non-null {@link CellValue} state:
+ * {@link org.eclipse.daanse.olap.api.result.NullValue#INSTANCE} if the cell
+ *   evaluates to MDX NULL (also used when the reader cannot evaluate the
+ *   cell at all, e.g. the request is unsatisfiable or, for the aggregating
+ *   reader, no aggregation contains the cell)
+ * {@link org.eclipse.daanse.olap.api.result.NotLoaded#INSTANCE} if the cell
+ *   is not in the cache yet (batching pass; the evaluation is marked dirty
+ *   and repeated after the batch load)
+ * {@link org.eclipse.daanse.olap.api.result.ErrorValue} if the cell
+ *   evaluates to an error
+ * an {@link org.eclipse.daanse.olap.api.result.ObjectValue} carrying the
+ *   value (often a {@link Double} or a {@link java.math.BigDecimal}),
+ *   otherwise
  *
  *
  * @author jhyde
@@ -59,25 +62,20 @@ public interface CellReader {
      * using the Aggregate function. These compound members are contained in the
      * evaluator.
      *
-     * If no aggregation contains the required cell, returns null.
-     *
-     * If the value is null, returns {@link Util#nullValue}.
-     *
-     * @return Cell value, or null if not found, or {@link Util#nullValue} if
-     * the value is null
-     */
-    Object get(RolapEvaluator evaluator);
+     * @return Cell value state; never Java null
+ */
+    CellValue get(RolapEvaluator evaluator);
 
     /**
      * Returns the number of times this cell reader has told a lie
      * (since creation), because the required cell value is not in the
      * cache.
-     */
+ */
     int getMissCount();
 
     /**
      * @return whether thus cell reader has any pending cell requests that are
      * not loaded yet.
-     */
+ */
     boolean isDirty();
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/result/FastBatchingCellReader.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/result/FastBatchingCellReader.java
@@ -38,6 +38,9 @@ import java.util.Set;
 import java.util.concurrent.Future;
 
 import org.eclipse.daanse.jdbc.db.dialect.api.Dialect;
+import org.eclipse.daanse.olap.api.result.CellValue;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.api.result.NullValue;
 import org.eclipse.daanse.olap.api.agg.OlapAggregationManager;
 import org.eclipse.daanse.olap.api.cache.CacheCommand;
 import org.eclipse.daanse.olap.api.exception.CellRequestQuantumExceededException;
@@ -87,18 +90,18 @@ public class FastBatchingCellReader implements CellReader {
      * the request count stays the same during an operation, you know that the
      * FastBatchingCellReader has not told any lies during that operation, and
      * therefore the result is true. The field is also useful for debugging.
-     */
+ */
     private int missCount;
 
     /**
      * Number of occasions that a requested cell was already in cache.
-     */
+ */
     private int hitCount;
 
     /**
      * Number of occasions that requested cell was in the process of being
      * loaded into cache but not ready.
-     */
+ */
     private int pendingCount;
 
     private final AggregationManager aggMgr;
@@ -111,7 +114,7 @@ public class FastBatchingCellReader implements CellReader {
 
     /**
      * Indicates that the reader has given incorrect results.
-     */
+ */
     private boolean dirty;
 
     private final List<CellRequest> cellRequests = new ArrayList<>();
@@ -125,7 +128,7 @@ public class FastBatchingCellReader implements CellReader {
      *                  to check for cancel
      * @param cube      Cube that requests belong to
      * @param aggMgr    Aggregation manager
-     */
+ */
     public FastBatchingCellReader(
         Execution execution,
         RolapCube cube,
@@ -149,22 +152,23 @@ public class FastBatchingCellReader implements CellReader {
     }
 
     @Override
-	public Object get(RolapEvaluator evaluator) {
+	public CellValue get(RolapEvaluator evaluator) {
         final CellRequest request =
             RolapAggregationManager.makeRequest(evaluator);
 
         if (request == null || request.isUnsatisfiable()) {
-            return Util.nullValue; // request not satisfiable.
+            return NullValue.INSTANCE; // request not satisfiable.
         }
 
         // Try to retrieve a cell and simultaneously pin the segment which
-        // contains it.
+        // contains it. The probe API uses the object convention (raw value /
+        // NullValue.INSTANCE / null-for-absent); this reader is the
+        // CellValue boundary.
         final Object o = aggMgr.getCellFromCache(request, pinnedSegments);
 
-        assert o != Boolean.TRUE : "getCellFromCache no longer returns TRUE";
         if (o != null) {
             ++hitCount;
-            return o;
+            return RolapAggregationManager.toCellValue(o, NullValue.INSTANCE);
         }
 
         // If this query has not had any cache misses, it's worth doing a
@@ -181,7 +185,7 @@ public class FastBatchingCellReader implements CellReader {
                     aggMgr.getCellFromCache(request, pinnedSegments);
                 if (o2 != null) {
                     ++hitCount;
-                    return o2;
+                    return RolapAggregationManager.toCellValue(o2, NullValue.INSTANCE);
                 }
             }
         }
@@ -189,7 +193,7 @@ public class FastBatchingCellReader implements CellReader {
         // if there is no such cell, record that we need to fetch it, and
         // return 'error'
         recordCellRequest(request);
-        return Util.valueNotReadyException;
+        return NotLoaded.INSTANCE;
     }
 
     @Override
@@ -222,7 +226,7 @@ public class FastBatchingCellReader implements CellReader {
      * Returns whether this reader has told a lie. This is the case if there
      * are pending batches to load or if {@link #setDirty(boolean)} has been
      * called.
-     */
+ */
     @Override
 	public boolean isDirty() {
         return dirty || !cellRequests.isEmpty();
@@ -263,7 +267,7 @@ public class FastBatchingCellReader implements CellReader {
      * needs to be made to the cache manager.
      *
      * @return Whether any aggregations were loaded.
-     */
+ */
     public boolean loadAggregations() {
         if (!isDirty()) {
             return false;
@@ -497,7 +501,7 @@ public class FastBatchingCellReader implements CellReader {
      * thread, potentially causing a deadlock when interleaved with
      * other threads that depend both on db connections and Actor responses.
      *
-     */
+ */
     private void preloadColumnCardinality(List<CellRequest> cellRequests) {
         List<BitKey> loaded = new ArrayList<>();
         for (CellRequest req : cellRequests) {
@@ -523,7 +527,7 @@ public class FastBatchingCellReader implements CellReader {
      *
      * @return Collection of segment headers and bodies suitable for rollup,
      * or null
-     */
+ */
     private Map<SegmentHeader, SegmentBody> findResidentRollupCandidate(
         Map<SegmentHeader, SegmentBody> headerBodies,
         BatchLoader.RollupInfo rollup)
@@ -569,7 +573,7 @@ public class FastBatchingCellReader implements CellReader {
      * Returns the SQL dialect. Overridden in some unit tests.
      *
      * @return Dialect
-     */
+ */
     public Dialect getDialect() {
 
         final RolapStar star = cube.getStar();
@@ -582,7 +586,7 @@ public class FastBatchingCellReader implements CellReader {
 
     /**
      * Sets the flag indicating that the reader has told a lie.
-     */
+ */
     void setDirty(boolean dirty) {
         this.dirty = dirty;
     }

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/result/RolapCell.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/result/RolapCell.java
@@ -70,6 +70,10 @@ import org.eclipse.daanse.olap.api.query.component.ResolvedFunCall;
 import org.eclipse.daanse.olap.api.query.component.UnresolvedFunCall;
 import org.eclipse.daanse.olap.api.result.Axis;
 import org.eclipse.daanse.olap.api.result.Cell;
+import org.eclipse.daanse.olap.api.result.ErrorValue;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.api.result.NullValue;
+import org.eclipse.daanse.olap.api.result.ObjectValue;
 import org.eclipse.daanse.olap.api.result.Position;
 import org.eclipse.daanse.olap.api.sql.SqlStatementI;
 import org.eclipse.daanse.olap.common.ConfigConstants;
@@ -112,7 +116,7 @@ public class RolapCell implements Cell {
     /**
      * @see mondrian.util.Bug#olap4jUpgrade Use
      * {@link mondrian.xmla.XmlaConstants}.ActionType.DRILLTHROUGH when present
-     */
+ */
     private static final int MDACTION_TYPE_DRILLTHROUGH = 0x100;
 
     private final RolapResult result;
@@ -127,7 +131,7 @@ public class RolapCell implements Cell {
      * @param result Result cell belongs to
      * @param pos Coordinates of cell
      * @param ci Cell information, containing value et cetera
-     */
+ */
     RolapCell(RolapResult result, int[] pos, RolapResult.CellInfo ci) {
         this.result = result;
         this.pos = pos;
@@ -151,10 +155,17 @@ public class RolapCell implements Cell {
 
     @Override
 	public Object getValue() {
-        if (ci.value == Util.nullValue) {
-            return null;
-        }
-        return ci.value;
+        // Exhaustive unwrap of the cell state (seam B). Contract of the
+        // public Cell API: NULL cells yield Java null, error cells yield
+        // the Throwable that caused the failure (pinned by an XMLA
+        // characterization test), regular cells the raw value.
+        return switch (ci.value) {
+            case null -> null;
+            case NullValue v -> null;
+            case NotLoaded n -> n;
+            case ErrorValue e -> e.cause();
+            case ObjectValue o -> o.value();
+        };
     }
 
     @Override
@@ -169,12 +180,15 @@ public class RolapCell implements Cell {
 
     @Override
 	public boolean isNull() {
-        return (Objects.equals(ci.value ,Util.nullValue));
+        // State check: NULL-ness is carried by the CellValue
+        // state, no sentinel or value comparison involved (a Java null means
+        // the cell was never evaluated, which renders as NULL as well).
+        return ci.value == null || ci.value instanceof NullValue;
     }
 
     @Override
 	public boolean isError() {
-        return (ci.value instanceof Throwable);
+        return (ci.value instanceof ErrorValue);
     }
 
     @Override
@@ -316,7 +330,7 @@ public class RolapCell implements Cell {
      * @return an instance of StarPredicate representing all
      * of the the positions from the slicer if it has more than one,
      * or null otherwise.
-     */
+ */
     private StarPredicate buildDrillthroughSlicerPredicate(
         Member[] membersForDrillthrough,
         Axis slicerAxis)
@@ -413,7 +427,7 @@ public class RolapCell implements Cell {
     /**
      * Returns appropriate non-virtual cube that will be used
      * for retrieving base star key column.
-     */
+ */
     private RolapCube getDrillThroughBaseCube() {
         if (result.getCube() instanceof RolapVirtualCube) {
             Member[] membersForDrillThrough = this.getMembersForDrillThrough();
@@ -432,7 +446,7 @@ public class RolapCell implements Cell {
      * and not possible for calculated measures.
      *
      * @return true if can drill through
-     */
+ */
     @Override
 	public boolean canDrillThrough() {
         if (!((Context<?>)(result.getExecution().getDaanseStatement().getDaanseConnection().getContext()))
@@ -565,7 +579,7 @@ public class RolapCell implements Cell {
      *                          queries easier for humans to understand.
      * @param logger Logger. If not null and debug is enabled, log SQL here
      * @return executed SQL statement
-     */
+ */
     public SqlStatementI drillThroughInternal(
         int maxRowCount,
         int firstRowOrdinal,
@@ -793,7 +807,7 @@ public class RolapCell implements Cell {
      * Calculated member with expression
      *     ([Measures].[Unit Sales], [Time].PrevMember) is not drillable
      *
-     */
+ */
     private static class DrillThroughVisitor extends MdxVisitorImpl {
         static final RuntimeException bomb = new RuntimeException();
         RolapCube cube = null;

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/result/RolapResult.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/result/RolapResult.java
@@ -43,6 +43,9 @@ import java.util.Set;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.InternalOperationAtom;
 import org.eclipse.daanse.mdx.model.api.expression.operation.OperationAtom;
+import org.eclipse.daanse.olap.api.result.CellValue;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.api.result.NullValue;
 import org.eclipse.daanse.olap.api.DataType;
 import org.eclipse.daanse.olap.api.Parameter;
 import org.eclipse.daanse.olap.api.access.HierarchyAccess;
@@ -161,7 +164,7 @@ public class RolapResult extends ResultBase {
    *          Execution of a statement
    * @param execute
    *          Whether to execute the query
-   */
+ */
   public RolapResult( final Execution execution, boolean execute ) {
     super( execution, null );
     this.maxEvalDepth = query.getConnection().getContext().getConfigValue(ConfigConstants.MAX_EVAL_DEPTH, ConfigConstants.MAX_EVAL_DEPTH_DEFAULT_VALUE, Integer.class);
@@ -736,7 +739,7 @@ public class RolapResult extends ResultBase {
    * hierarchy. This is used with compound slicer evaluation to avoid the slicer tuple list from interacting with the
    * aggregate calc which rolls up the set. This member will contain the AggregateCalc which rolls up the set on the
    * slicer.
-   */
+ */
   private Member setPlaceholderSlicerAxis( final RolapMember member, final Calc calc, boolean setAxis,
       TupleList tupleList, int solveOrder ) {
     ValueFormatter formatter;
@@ -788,7 +791,7 @@ public class RolapResult extends ResultBase {
    * @param evaluator
    *          The slicer evaluator.
    * @return a new list of tuples reduced in size.
-   */
+ */
   private TupleList removeUnaryMembersFromTupleList( TupleList tupleList, RolapEvaluator evaluator ) {
     // we can remove any unary coordinates from the compound slicer, and
     // account for them in the slicer evaluator.
@@ -990,7 +993,7 @@ public class RolapResult extends ResultBase {
    *          List of root Members for Hierarchies that have no ALL Member.
    * @param measureMembers
    *          List all Measures
-   */
+ */
   protected void loadSpecialMembers( List<Member> nonDefaultAllMembers, List<List<Member>> nonAllMembers,
       List<Member> measureMembers ) {
     CatalogReader schemaReader = evaluator.getCatalogReader();
@@ -1047,7 +1050,7 @@ public Axis[] getAxes() {
    * @param pos
    *          Cell position.
    * @return the Cell associated with the Cell position.
-   */
+ */
   @Override
 public Cell getCell( int[] pos ) {
     if ( pos.length != point.size() ) {
@@ -1071,7 +1074,7 @@ public Cell getCell( int[] pos ) {
           throw Util.newError( "coordinates out of range" );
         }
       }
-      ci.value = Util.nullValue;
+      ci.value = NullValue.INSTANCE;
     }
 
     return new RolapCell( this, pos.clone(), ci );
@@ -1175,7 +1178,7 @@ public Cell getCell( int[] pos ) {
    * @param contextEvaluator
    *          Evaluation context (optional)
    * @return Result
-   */
+ */
   public Object evaluateExp( Calc calc, RolapEvaluator slicerEvaluator, Evaluator contextEvaluator ) {
     int attempt = 0;
 
@@ -1301,8 +1304,13 @@ public Cell getCell( int[] pos ) {
 //            discard( e );
         }
 
-        if (ci != null && o != Util.valueNotReadyException ) {
-          ci.value = o;
+        // Store the cell state as a CellValue. The evaluator delivers
+        // calc-layer conventions (Java null for MDX NULL, a Throwable for
+        // an evaluation error); NotLoaded results belong to a dirty pass
+        // and are discarded.
+        final CellValue cv = CellValue.fromLegacyValue( o );
+        if ( ci != null && !( cv instanceof NotLoaded ) ) {
+          ci.value = cv;
         }
       }
     } else {
@@ -1406,7 +1414,7 @@ public Cell getCell( int[] pos ) {
    *
    * Because all children of [Store].[All Stores].[USA].[CA] are included.
    * 
-   */
+ */
   private List<Member> processDistinctMeasureExpr( List<Member> tuple, RolapBaseCubeMeasure measure ) {
     for ( Member member : tuple ) {
       if ( !( member instanceof VisualTotalMember ) ) {
@@ -1441,7 +1449,7 @@ public Cell getCell( int[] pos ) {
    *
    * This method can be expensive, because the ordinal is computed from the length of the axes, and therefore the axes
    * need to be instantiated.
-   */
+ */
   public int getCellOrdinal( int[] pos ) {
     if ( modulos == null ) {
       makeModulos();
@@ -1455,7 +1463,7 @@ public Cell getCell( int[] pos ) {
    *
    * To create the calculator, any axis that is based upon an Iterable is converted into a List - thus increasing memory
    * usage.
-   */
+ */
   protected void makeModulos() {
     modulos = Modulos.Generator.create( axes );
   }
@@ -1466,7 +1474,7 @@ public Cell getCell( int[] pos ) {
    * @param pos
    *          Coordinates of cell
    * @return Members which form the context of the given cell
-   */
+ */
   public RolapMember[] getCellMembers( int[] pos ) {
     RolapMember[] members = (RolapMember[]) evaluator.getMembers().clone();
     for ( int i = 0; i < pos.length; i++ ) {
@@ -1524,7 +1532,7 @@ public Cell getCell( int[] pos ) {
    * counts how many Members are on each axis and forms the product, the totalCellCount which is checked against the
    * ResultLimit property value.
    * 
-   */
+ */
   private static class AxisMemberList implements Iterable<Member> {
     private final List<Member> members;
     // Also store members by hierarchy for faster de-duplication and also reuse in RolapEvaluator
@@ -1671,11 +1679,11 @@ public Cell getCell( int[] pos ) {
    * 
    * Named sets are always evaluated in the context of the slicer.
    *
-   */
+ */
   public static class RolapResultEvaluatorRoot extends RolapEvaluatorRoot {
     /**
      * Maps the names of sets to their values. Populated on demand.
-     */
+ */
     private final Map<String, RolapSetEvaluator> setEvaluators = new HashMap<>();
     private final Map<String, RolapNamedSetEvaluator> namedSetEvaluators =
         new HashMap<>();
@@ -1799,7 +1807,7 @@ public Cell getCell( int[] pos ) {
    * {@link CellFormatterValueFormatter}, which formats using a user-registered {@link CellFormatter}; and
    * {@link FormatValueFormatter}, which takes the {@link Locale} object.
    *
-   */
+ */
   public interface ValueFormatter {
     /**
      * Formats a value according to a format string.
@@ -1809,12 +1817,12 @@ public Cell getCell( int[] pos ) {
      * @param formatString
      *          Format string
      * @return Formatted value
-     */
+ */
     String format( Object value, String formatString );
 
     /**
      * Formatter that always returns the empty string.
-     */
+ */
     public static final ValueFormatter EMPTY = new ValueFormatter() {
       @Override
 	public String format( Object value, String formatString ) {
@@ -1825,7 +1833,7 @@ public Cell getCell( int[] pos ) {
 
   /**
    * A CellFormatterValueFormatter uses a user-defined {@link CellFormatter} to format values.
-   */
+ */
   public static class CellFormatterValueFormatter implements ValueFormatter {
     final CellFormatter cf;
 
@@ -1834,7 +1842,7 @@ public Cell getCell( int[] pos ) {
      *
      * @param cf
      *          Cell formatter
-     */
+ */
     public CellFormatterValueFormatter( CellFormatter cf ) {
       this.cf = cf;
     }
@@ -1848,7 +1856,7 @@ public Cell getCell( int[] pos ) {
   /**
    * A FormatValueFormatter takes a {@link Locale} as a parameter and uses it to get the {@link mondrian.util.Format} to
    * be used in formatting an Object value with a given format string.
-   */
+ */
   static class FormatValueFormatter implements ValueFormatter {
     final Locale locale;
 
@@ -1857,16 +1865,13 @@ public Cell getCell( int[] pos ) {
      *
      * @param locale
      *          Locale
-     */
+ */
     FormatValueFormatter( Locale locale ) {
       this.locale = locale;
     }
 
     @Override
 	public String format( Object value, String formatString ) {
-      if ( Objects.equals( value ,Util.nullValue )) {
-        value = null;
-      }
       if ( value instanceof Throwable ) {
         return "#ERR: " + value.toString();
       }
@@ -1882,7 +1887,7 @@ public Cell getCell( int[] pos ) {
   /**
    * Synchronized Map from Locale to ValueFormatter. It is expected that there will be only a small number of Locale's.
    * Should these be a WeakHashMap?
-   */
+ */
   protected static final Map<Locale, ValueFormatter> formatValueFormatters =
       Collections.synchronizedMap( new HashMap<Locale, ValueFormatter>() );
 
@@ -1892,9 +1897,16 @@ public Cell getCell( int[] pos ) {
    *
    * 
    * During the evaluation stage they are mutable but after evaluation has finished they are not changed.
-   */
+ */
   static public class CellInfo {
-    public Object value;
+    /**
+     * State of the cell: null while the cell has not been evaluated yet,
+     * otherwise one of the {@link CellValue} states ({@link NullValue},
+     * {@link org.eclipse.daanse.olap.api.result.ErrorValue},
+     * {@link org.eclipse.daanse.olap.api.result.ObjectValue}).
+     * {@link NotLoaded} is never stored; dirty-pass results are discarded.
+ */
+    public CellValue value;
     public String formatString;
     public ValueFormatter valueFormatter;
     public long key;
@@ -1904,7 +1916,7 @@ public Cell getCell( int[] pos ) {
      *
      * @param key
      *          Ordinal representing the position of a cell
-     */
+ */
     CellInfo( long key ) {
       this( key, null, null, ValueFormatter.EMPTY );
     }
@@ -1920,8 +1932,8 @@ public Cell getCell( int[] pos ) {
      *          Format string of cell, or null
      * @param valueFormatter
      *          Formatter for cell, or null
-     */
-    CellInfo( long key, Object value, String formatString, ValueFormatter valueFormatter ) {
+ */
+    CellInfo( long key, CellValue value, String formatString, ValueFormatter valueFormatter ) {
       this.key = key;
       this.value = value;
       this.formatString = formatString;
@@ -1952,33 +1964,42 @@ public Cell getCell( int[] pos ) {
      * Returns the formatted value of the Cell
      *
      * @return formatted value of the Cell
-     */
+ */
     public String getFormatValue() {
-      return valueFormatter.format( value, formatString );
+      // Unwrap the cell state for the formatter: NULL cells become Java
+      // null (renders as the empty string unless the format string has a
+      // NULL section), error cells the Throwable (produces "#ERR: ..."),
+      // plain values unwrapped.
+      final Object raw = switch ( value ) {
+        case null -> null;
+        case NullValue v -> null;
+        default -> value.toLegacyValue();
+      };
+      return valueFormatter.format( raw, formatString );
     }
   }
 
   /**
    * API for the creation and lookup of {@link CellInfo} objects. There are two implementations, one that uses a Map for
    * storage and the other uses an ObjectPool.
-   */
+ */
   interface CellInfoContainer {
     /**
      * Returns the number of CellInfo objects in this container.
      *
      * @return the number of CellInfo objects.
-     */
+ */
     int size();
 
     /**
      * Reduces the size of the internal data structures needed to support the current entries. This should be called
      * after all CellInfo objects have been added to container.
-     */
+ */
     void trimToSize();
 
     /**
      * Removes all CellInfo objects from container. Does not change the size of the internal data structures.
-     */
+ */
     void clear();
 
     /**
@@ -1987,7 +2008,7 @@ public Cell getCell( int[] pos ) {
      * @param pos
      *          where to store CellInfo object.
      * @return the newly create CellInfo object.
-     */
+ */
     CellInfo create( int[] pos );
 
     /**
@@ -1996,7 +2017,7 @@ public Cell getCell( int[] pos ) {
      * @param pos
      *          where to find the CellInfo object.
      * @return the CellInfo found or null.
-     */
+ */
     CellInfo lookup( int[] pos );
   }
 
@@ -2006,7 +2027,7 @@ public Cell getCell( int[] pos ) {
    * 
    * Note that the CellKey point instance variable is the same Object (NOT a copy) that is used and modified during the
    * recursive calls to executeStripe - the create method relies on this fact.
-   */
+ */
   static class CellInfoMap implements CellInfoContainer {
     private final Map<CellKey, CellInfo> map;
     private final CellKey point;
@@ -2016,7 +2037,7 @@ public Cell getCell( int[] pos ) {
      *
      * @param point
      *          Cell position
-     */
+ */
     CellInfoMap( CellKey point ) {
       this.point = point;
       this.map = new HashMap<>();
@@ -2064,19 +2085,19 @@ public Cell getCell( int[] pos ) {
    * it is an Iterable, then one has to use one of the MAX_AXIS_SIZE values. Given that this information is available
    * when one recursives down to the next executeStripe call, the Cell ordinal, the position integer array
    * could converted to an long, could be generated on the call stack!! Just a thought for the future.
-   */
+ */
   static class CellInfoPool implements CellInfoContainer {
     /**
      * The maximum number of Members, 2,147,483,647, that can be any given Axis when the number of Axes is 2.
-     */
+ */
     protected static final long MAX_AXIS_SIZE_2 = 2147483647;
     /**
      * The maximum number of Members, 2,000,000, that can be any given Axis when the number of Axes is 3.
-     */
+ */
     protected static final long MAX_AXIS_SIZE_3 = 2000000;
     /**
      * The maximum number of Members, 50,000, that can be any given Axis when the number of Axes is 4.
-     */
+ */
     protected static final long MAX_AXIS_SIZE_4 = 50000;
 
     /**
@@ -2109,14 +2130,14 @@ public Cell getCell( int[] pos ) {
      * For five or more axes, the maximum number of members per axis based upon the root of the maximum 'long' number,
      * start getting too small to guarantee that it will be smaller than the number of members on a given axis and so we
      * must resort to the Map-base Cell container.
-     */
+ */
     interface CellKeyMaker {
       long generate( int[] pos );
     }
 
     /**
      * For axis of size 0.
-     */
+ */
     static class Zero implements CellKeyMaker {
       @Override
 	public long generate( int[] pos ) {
@@ -2126,7 +2147,7 @@ public Cell getCell( int[] pos ) {
 
     /**
      * For axis of size 1.
-     */
+ */
     static class One implements CellKeyMaker {
       @Override
 	public long generate( int[] pos ) {
@@ -2136,7 +2157,7 @@ public Cell getCell( int[] pos ) {
 
     /**
      * For axis of size 2.
-     */
+ */
     static class Two implements CellKeyMaker {
       @Override
 	public long generate( int[] pos ) {
@@ -2148,7 +2169,7 @@ public Cell getCell( int[] pos ) {
 
     /**
      * For axis of size 3.
-     */
+ */
     static class Three implements CellKeyMaker {
       @Override
 	public long generate( int[] pos ) {
@@ -2161,7 +2182,7 @@ public Cell getCell( int[] pos ) {
 
     /**
      * For axis of size 4.
-     */
+ */
     static class Four implements CellKeyMaker {
       @Override
 	public long generate( int[] pos ) {

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/sqlbuild/StarPredicateTranslator.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/sqlbuild/StarPredicateTranslator.java
@@ -289,7 +289,7 @@ public final class StarPredicateTranslator {
         for (RolapStar.Column col : columns) {
             int nulls = 0;
             for (Map<Integer, ValueColumnPredicate> m : rowMaps) {
-                if (isNullValue(m.get(col.getBitPosition()))) {
+                if (isSqlNullValue(m.get(col.getBitPosition()))) {
                     nulls++;
                 }
             }
@@ -358,7 +358,7 @@ public final class StarPredicateTranslator {
     }
 
     /** Whether a per-column predicate carries the SQL null value (rendered {@code col IS NULL}). */
-    private static boolean isNullValue(ValueColumnPredicate v) {
+    private static boolean isSqlNullValue(ValueColumnPredicate v) {
         return v == null || v.getValue() == null || v.getValue() == Util.sqlNullValue;
     }
 

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapStar.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/star/RolapStar.java
@@ -124,26 +124,26 @@ public class RolapStar {
 
     /**
      * Number of columns (column and columnName).
-     */
+ */
     private int columnCount;
 
     /**
      * Keeps track of the columns across all tables. Should have
      * a number of elements equal to columnCount.
-     */
+ */
     private final List<Column> columnList = new ArrayList<>();
 
 
     /**
      * If true, then database aggregation information is cached, otherwise
      * it is flushed after each query.
-     */
+ */
     private boolean cacheAggregations;
 
     /**
      * Partially ordered list of AggStars associated with this RolapStar's fact
      * table.
-     */
+ */
     private final List<AggStar> aggStars = new LinkedList<>();
 
 
@@ -161,7 +161,7 @@ public class RolapStar {
      * Creates a RolapStar. Please use
      * RolapCatalog.RolapStarRegistry#getOrCreateStar to create a
      * RolapStar.
-     */
+ */
     protected RolapStar(
         final RolapCatalog catalog,
         final Context context,
@@ -187,8 +187,8 @@ public class RolapStar {
      * step will presumably be to request a segment that contains the cell
      * from the global cache, external cache, or by issuing a SQL statement.
      *
-     * Returns {@link Util#nullValue} if a segment contains the cell and the
-     * cell's value is null.
+     * Returns {@link org.eclipse.daanse.olap.api.result.NullValue#INSTANCE}
+     * if a segment contains the cell and the cell's value is null.
      *
      * If pinSet is not null, pins the segment that holds it
      * into the local cache. pinSet ensures that a segment is
@@ -198,9 +198,11 @@ public class RolapStar {
      *
      * @param pinSet Set into which to pin the segment; or null
      *
-     * @return Cell value, or {@link Util#nullValue} if the cell value is null,
-     * or null if the cell is not in any segment in the local cache.
-     */
+     * @return Cell value, or
+     * {@link org.eclipse.daanse.olap.api.result.NullValue#INSTANCE} if the
+     * cell value is null, or null if the cell is not in any segment in the
+     * local cache.
+ */
     public Object getCellFromCache(
         CellRequest request,
         RolapAggregationManager.PinSet pinSet)
@@ -287,7 +289,7 @@ public class RolapStar {
      * it is accessed via a thread-local, the data structures can be accessed
      * without acquiring locks.
      *
-     */
+ */
     public static class Bar {
         /** Holds all thread-local aggregations of this star. */
 
@@ -411,7 +413,7 @@ public class RolapStar {
      * @param primaryKey the join key of the relation
      * @param primaryKeyTable the join table of the relation
      * @return if necessary a new relation that has been re-aliased
-     */
+ */
     public org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource getUniqueRelation(
         org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource rel,
         String factForeignKey,
@@ -515,7 +517,7 @@ public class RolapStar {
     /**
      * Returns this RolapStar's column count. After a star has been created with
      * all of its columns, this is the number of columns in the star.
-     */
+ */
     public int getColumnCount() {
         return columnCount;
     }
@@ -523,7 +525,7 @@ public class RolapStar {
     /**
      * This is used by the {@link Column} constructor to get a unique id (per
      * its parent {@link RolapStar}).
-     */
+ */
     private int nextColumnCount() {
         return columnCount++;
     }
@@ -532,7 +534,7 @@ public class RolapStar {
      * Place holder in case in the future we wish to be able to
      * reload aggregates. In that case, if aggregates had already been loaded,
      * i.e., this star has some aggstars, then those aggstars are cleared.
-     */
+ */
     public void prepareToLoadAggregates() {
         aggStars.clear();
     }
@@ -543,7 +545,7 @@ public class RolapStar {
      * Internally the AggStars are added in sort order, smallest row count
      * to biggest, so that the most efficient AggStar is encountered first;
      * ties do not matter.
-     */
+ */
     public void addAggStar(AggStar aggStar) {
         // Add it before the first AggStar which is larger, if there is one.
         boolean chooseAggregateByVolume = catalog.getInternalConnection().getContext().getConfigValue(ConfigConstants.CHOOSE_AGGREGATE_BY_VOLUME, ConfigConstants.CHOOSE_AGGREGATE_BY_VOLUME_DEFAULT_VALUE ,Boolean.class);
@@ -564,7 +566,7 @@ public class RolapStar {
 
     /**
      * Clears the list of agg stars.
-     */
+ */
     void clearAggStarList() {
         aggStars.clear();
     }
@@ -572,7 +574,7 @@ public class RolapStar {
     /**
      * Reorder the list of aggregate stars. This should be called if the
      * algorithm used to order the AggStars has been changed.
-     */
+ */
     public void reOrderAggStarList() {
         List<AggStar> oldList = new ArrayList<>(aggStars);
         aggStars.clear();
@@ -584,7 +586,7 @@ public class RolapStar {
     /**
      * Returns this RolapStar's aggregate table AggStars, ordered in ascending
      * order of size.
-     */
+ */
     public List<AggStar> getAggStars() {
         return aggStars;
     }
@@ -593,7 +595,7 @@ public class RolapStar {
      * Returns the fact table at the center of this RolapStar.
      *
      * @return fact table
-     */
+ */
     public Table getFactTable() {
         return factTable;
     }
@@ -601,7 +603,7 @@ public class RolapStar {
     /**
      * Creates an empty {@link QueryRecorder} for a query against this star (the accumulation
      * surface producers record onto).
-     */
+ */
     public QueryRecorder newQueryRecorder() {
         return new QueryRecorder(
             context.getConfigValue(ConfigConstants.GENERATE_FORMATTED_SQL, ConfigConstants.GENERATE_FORMATTED_SQL_DEFAULT_VALUE, Boolean.class));
@@ -609,7 +611,7 @@ public class RolapStar {
 
     /**
      * Returns this RolapStar's SQL dialect.
-     */
+ */
     public Dialect getDialect() {
         return context.getDialect();
     }
@@ -624,7 +626,7 @@ public class RolapStar {
      * caching turned off, then caching is turned off for all of them.
      *
      * @param cacheAggregations Whether to cache database aggregation
-     */
+ */
     public void setCacheAggregations(boolean cacheAggregations) {
         // this can only change from true to false
         this.cacheAggregations = cacheAggregations;
@@ -635,7 +637,7 @@ public class RolapStar {
      * Returns whether the this RolapStar cache aggregates.
      *
      * @see #setCacheAggregations(boolean)
-     */
+ */
     public boolean isCacheAggregations() {
         return this.cacheAggregations;
     }
@@ -650,7 +652,7 @@ public class RolapStar {
      *
      * @param forced If true, clears cached aggregations regardless of any other
      *   settings.  If false, clears only cache from the current thread
-     */
+ */
     public void clearCachedAggregations(boolean forced) {
         if (forced || !cacheAggregations || isCacheDisabled()) {
             if (LOGGER.isDebugEnabled()) {
@@ -675,7 +677,7 @@ public class RolapStar {
      * When a new aggregation is created, it is marked as thread local.
      *
      * @param aggregationKey this is the constrained column bitkey
-     */
+ */
     public Aggregation lookupOrCreateAggregation(
         AggregationKey aggregationKey)
     {
@@ -701,7 +703,7 @@ public class RolapStar {
      *
      * Must be called from synchronized context.
      *
-     */
+ */
     public Aggregation lookupSegment(AggregationKey aggregationKey) {
         return localBars.get().aggregations.get(aggregationKey);
     }
@@ -712,7 +714,7 @@ public class RolapStar {
      * Returns the DataSource used to connect to the underlying DBMS.
      *
      * @return DataSource
-     */
+ */
     public DataSource getDataSource() {
         return context.getDataSource();
     }
@@ -722,21 +724,21 @@ public class RolapStar {
      * Returns the Context
      *
      * @return Context
-     */
+ */
     public Context<?> getContext() {
         return context;
     }
 
     /**
      * Retrieves the {@link RolapStar.Measure} in which a measure is stored.
-     */
+ */
     public static Measure getStarMeasure(Member member) {
         return (Measure) ((RolapStoredMeasure) member).getStarMeasure();
     }
 
     /**
      * Retrieves a named column, returns null if not found.
-     */
+ */
     public Column[] lookupColumns(String tableAlias, String columnName) {
         final Table table = factTable.findDescendant(tableAlias);
         return (table == null) ? null : table.lookupColumns(columnName);
@@ -744,7 +746,7 @@ public class RolapStar {
 
     /**
      * This is used by TestAggregationManager only.
-     */
+ */
     public Column lookupColumn(String tableAlias, String columnName) {
         final Table table = factTable.findDescendant(tableAlias);
         return (table == null) ? null : table.lookupColumn(columnName);
@@ -764,7 +766,7 @@ public class RolapStar {
 
     /**
      * Returns a list of all aliases used in this star.
-     */
+ */
     public List<String> getAliasList() {
         List<String> aliasList = new ArrayList<>();
         if (factTable != null) {
@@ -775,7 +777,7 @@ public class RolapStar {
 
     /**
      * Finds all of the table aliases in a table and its children.
-     */
+ */
     private static void collectAliases(List<String> aliasList, Table table) {
         aliasList.add(table.getAlias());
         for (Table child : table.children) {
@@ -787,7 +789,7 @@ public class RolapStar {
      * Collects all columns in this table and its children.
      * If joinColumn is specified, only considers child tables
      * joined by the given column.
-     */
+ */
     public static void collectColumns(
         Collection<Column> columnList,
         Table table,
@@ -809,7 +811,7 @@ public class RolapStar {
      * Adds a column to the star's list of all columns across all tables.
      *
      * @param c the column to add
-     */
+ */
     private void addColumn(Column c) {
         columnList.add(c.getBitPosition(), c);
     }
@@ -819,7 +821,7 @@ public class RolapStar {
      *
      * @param bitPos bit position to look up
      * @return column at the given position
-     */
+ */
     public Column getColumn(int bitPos) {
         return columnList.get(bitPos);
     }
@@ -843,7 +845,7 @@ public class RolapStar {
      * @param pw Writer
      * @param prefix Prefix to print at the start of each line
      * @param structure Whether to print the structure of the star
-     */
+ */
     public void print(PrintWriter pw, String prefix, boolean structure) {
         if (structure) {
             pw.print(prefix);
@@ -862,7 +864,7 @@ public class RolapStar {
 
     /**
      * A column in a star schema.
-     */
+ */
     public static class Column {
         public static final Comparator<Column> COMPARATOR =
             new Comparator<>() {
@@ -886,7 +888,7 @@ public class RolapStar {
         /**
          * When a Column is a column, and not a Measure, the parent column
          * is the coloumn associated with next highest Level.
-         */
+ */
         private final Column parentColumn;
 
         /**
@@ -894,13 +896,13 @@ public class RolapStar {
          * table generation. For multiple dimension usages, multiple shared
          * dimension or unshared dimension with the same column names,
          * this is used to disambiguate aggregate column names.
-         */
+ */
         private final String usagePrefix;
         /**
          * This is only used in RolapAggregationManager and adds
          * non-constraining columns making the drill-through queries easier for
          * humans to understand.
-         */
+ */
         private final Column nameColumn;
 
         private boolean isNameColumn;
@@ -910,7 +912,7 @@ public class RolapStar {
         /**
          * The estimated cardinality of the column.
          * {@link Integer#MIN_VALUE} means unknown.
-         */
+ */
         private AtomicLong approxCardinality = new AtomicLong(
             Long.MIN_VALUE);
 
@@ -961,7 +963,7 @@ public class RolapStar {
          * Fake column.
          *
          * @param datatype Datatype
-         */
+ */
         protected Column(Datatype datatype)
         {
             this(
@@ -1037,7 +1039,7 @@ public class RolapStar {
         /**
          * Generates a SQL expression, which typically this looks like
          * this: <i>tableName</i>.<i>columnName</i>.
-         */
+ */
         public String generateExprString(Dialect dialect) {
             return RolapStar.generateExprString(getExpression(), dialect);
         }
@@ -1048,7 +1050,7 @@ public class RolapStar {
          * the cardinality and stores it in the cache.
          *
          * @return the column cardinality.
-         */
+ */
         public long getCardinality() {
             if (approxCardinality.get() < 0) {
                 approxCardinality.set(
@@ -1073,7 +1075,7 @@ public class RolapStar {
          *
          * @param pw Print writer
          * @param prefix Prefix to print first, such as spaces for indentation
-         */
+ */
         public void print(PrintWriter pw, String prefix) {
             pw.print(prefix);
             pw.print(getName());
@@ -1097,7 +1099,7 @@ public class RolapStar {
      *
      * A measure is basically just a column; except that its
      * {@link #aggregator} defines how it is to be rolled up.
-     */
+ */
     public static class Measure extends Column {
         private final String cubeName;
         private final Aggregator aggregator;
@@ -1174,7 +1176,7 @@ public class RolapStar {
      * table, and a condition which specifies how it is joined to its parent.
      * So the star schema is, in effect, a hierarchy with the fact table at
      * its root.
-     */
+ */
     public static class Table {
         private final RolapStar star;
         private final org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation;
@@ -1208,7 +1210,7 @@ public class RolapStar {
         /**
          * Returns the condition by which a dimension table is connected to its
          * {@link #getParentTable() parent}; or null if this is the fact table.
-         */
+ */
         public Condition getJoinCondition() {
             return joinCondition;
         }
@@ -1216,7 +1218,7 @@ public class RolapStar {
         /**
          * Returns this table's parent table, or null if this is the fact table
          * (which is at the center of the star).
-         */
+ */
         public Table getParentTable() {
             return parent;
         }
@@ -1232,7 +1234,7 @@ public class RolapStar {
          * Note: This method is slow, but that's acceptable because it is
          * only used for tracing. It would be more efficient to store an
          * array in the {@link RolapStar} mapping column ordinals to columns.
-         */
+ */
         private void collectColumns(BitKey bitKey, List<Column> list) {
             for (Column column : getColumns()) {
                 if (bitKey.get(column.getBitPosition())) {
@@ -1246,7 +1248,7 @@ public class RolapStar {
 
         /**
          * Returns an array of all columns in this star with a given name.
-         */
+ */
         public Column[] lookupColumns(String columnName) {
             List<Column> l = new ArrayList<>();
             for (Column column : getColumns()) {
@@ -1283,7 +1285,7 @@ public class RolapStar {
         /**
          * Given a Expression return a column with that expression
          * or null.
-         */
+ */
         private Column lookupColumnByExpression(SqlExpression expr) {
             for (Column column : getColumns()) {
                 if (column instanceof Measure) {
@@ -1315,7 +1317,7 @@ public class RolapStar {
         /**
          * Look up a {@link Measure} by its name.
          * Returns null if not found.
-         */
+ */
         public Measure lookupMeasureByName(String cubeName, String name) {
             for (Column column : getColumns()) {
                 if (column instanceof Measure measure && measure.getName().equals(name)
@@ -1354,7 +1356,7 @@ public class RolapStar {
         /**
          * Sometimes one need to get to the "real" name when the table has
          * been given an alias.
-         */
+ */
         public String getTableName() {
             if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.TableSource t) {
                 return t.getTable().getName();
@@ -1393,7 +1395,7 @@ public class RolapStar {
         /**
          * Decrements the column counter; used if a newly
          * created column is found to already exist.
-         */
+ */
         private int decrementColumnCount() {
             return star.columnCount--;
         }
@@ -1407,7 +1409,7 @@ public class RolapStar {
          * @param cube Cube
          * @param level Level
          * @param parentColumn Parent column
-         */
+ */
         public synchronized Column makeColumns(
             RolapCube cube,
             RolapCubeLevel level,
@@ -1648,7 +1650,7 @@ public class RolapStar {
          * already present, does not create it again. Stores the unaliased
          * table names to RolapStar.Table mapping associated with the
          * input cube.
-         */
+ */
         public synchronized Table addJoin(
             RolapCube cube,
             org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relationOrJoin,
@@ -1716,7 +1718,7 @@ public class RolapStar {
         /**
          * Returns a child relation which maps onto a given relation, or null
          * if there is none.
-         */
+ */
         public Table findChild(
         		org.eclipse.daanse.rolap.mapping.model.database.source.RelationalSource relation,
             Condition joinCondition)
@@ -1742,7 +1744,7 @@ public class RolapStar {
 
         /**
          * Returns a descendant with a given alias, or null if none found.
-         */
+ */
         public Table findDescendant(String seekAlias) {
             if (getAlias().equals(seekAlias)) {
                 return this;
@@ -1758,7 +1760,7 @@ public class RolapStar {
 
         /**
          * Returns an ancestor with a given alias, or null if not found.
-         */
+ */
         public Table findAncestor(String tableName) {
             for (Table t = this; t != null; t = t.parent) {
                 if (RelationUtil.getAlias(t.relation).equals(tableName)) {
@@ -1781,7 +1783,7 @@ public class RolapStar {
          *     the table before and if that happens you want to do nothing.
          * @param joinToParent Pass in true if you are constraining a cell
          *     calculation, false if you are retrieving members.
-         */
+ */
         public void addToFrom(
             QueryRecorder query,
             boolean failIfExists,
@@ -1804,14 +1806,14 @@ public class RolapStar {
 
         /**
          * Returns a list of child {@link Table}s.
-         */
+ */
         public List<Table> getChildren() {
             return children;
         }
 
         /**
          * Returns a list of this table's {@link Column}s.
-         */
+ */
         public List<Column> getColumns() {
             return columnList;
         }
@@ -1820,7 +1822,7 @@ public class RolapStar {
          * Finds the child table of the fact table with the given columnName
          * used in its left join condition. This is used by the AggTableManager
          * while characterizing the fact table columns.
-         */
+ */
         public RolapStar.Table findTableWithLeftJoinCondition(
             final String columnName)
         {
@@ -1837,7 +1839,7 @@ public class RolapStar {
          * This is used during aggregate table validation to make sure that the
          * mapping from for the aggregate join condition is valid. It returns
          * the child table with the matching left join condition.
-         */
+ */
         public RolapStar.Table findTableWithLeftCondition(
             final RolapSqlExpression left)
         {
@@ -1852,7 +1854,7 @@ public class RolapStar {
 
         /**
          * Note: I do not think that this is ever true.
-         */
+ */
         public boolean isFunky() {
             return (relation == null);
         }
@@ -1880,7 +1882,7 @@ public class RolapStar {
 
         /**
          * Prints this table and its children.
-         */
+ */
         public void print(PrintWriter pw, String prefix) {
             pw.print(prefix);
             pw.println("Table:");
@@ -1915,7 +1917,7 @@ public class RolapStar {
 
         /**
          * Returns whether this table has a column with the given name.
-         */
+ */
         public boolean containsColumn(String columnName) {
             if (relation instanceof org.eclipse.daanse.rolap.mapping.model.database.source.JoinSource) {
                 // todo: Deal with join.
@@ -2037,7 +2039,7 @@ public class RolapStar {
 
         /**
          * Prints this table and its children.
-         */
+ */
         public void print(PrintWriter pw, String prefix) {
             Dialect dialect = table.star.getDialect();
             pw.print(prefix);
@@ -2066,7 +2068,7 @@ public class RolapStar {
     /**
      * Creates a copy of an expression, everywhere replacing one alias
      * with another.
-     */
+ */
     public static class AliasReplacer {
         private final String oldAlias;
         private final String newAlias;
@@ -2111,7 +2113,7 @@ public class RolapStar {
 
     /**
      * Comparator to compare columns based on their name and table that contains them
-     */
+ */
     public static class ColumnComparator implements Comparator<Column> {
 
         public static final ColumnComparator instance = new ColumnComparator();
@@ -2122,7 +2124,7 @@ public class RolapStar {
         /* Compares two columns by their names.
          * If the names of the columns do not differ,
          * compare the tables to which the columns belong
-         */
+ */
         @Override
 		public int compare(Column o1, Column o2) {
           int result = o1.getName().compareTo(o2.getName());

--- a/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/ScenarioImpl.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/writeback/ScenarioImpl.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.daanse.jdbc.db.api.type.Datatype;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
 import org.eclipse.daanse.olap.api.DataTypeJdbc;
 import org.eclipse.daanse.olap.api.calc.Calc;
 import org.eclipse.daanse.olap.api.connection.Connection;
@@ -69,7 +70,7 @@ public class ScenarioImpl implements Scenario {
 
     /**
      * Creates a ScenarioImpl.
-     */
+ */
     public ScenarioImpl() {
         id = nextId++;
     }
@@ -107,7 +108,7 @@ public class ScenarioImpl implements Scenario {
      * @param currentValue Current value
      * @param allocationPolicy Allocation policy
      * @param allocationArgs Additional arguments of allocation policy
-     */
+ */
     @Override
     public void setCellValue(
         Connection connection,
@@ -261,7 +262,7 @@ public class ScenarioImpl implements Scenario {
      * are ignored — text cells are not "spread" across descendants the way
      * numeric values are; the per-level rollup happens on the read side via
      * the {@code TextAggMeasure}'s ListAgg aggregator.
-     */
+ */
     private void writeTextRow(
             RolapWritebackTable writebackTable,
             RolapWritebackMeasure target,
@@ -319,7 +320,7 @@ public class ScenarioImpl implements Scenario {
      * intermediate (non-leaf) members are written verbatim because that's
      * exactly what the user clicked on; the read-side {@code TextAggMeasure}
      * aggregator rolls descendants in via the standard SQL aggregation path.
-     */
+ */
     private Object findKeyForDimension(RolapWritebackAttribute attr, List<Member> members) {
         String dimName = attr.getDimension().getName();
         for (int i = 1; i < members.size(); i++) {
@@ -356,7 +357,7 @@ public class ScenarioImpl implements Scenario {
      *
      * @param member Wrapper member
      * @return Wrapped scenario
-     */
+ */
     public static Scenario forMember(final Member member) {
         if (isScenario(member.getHierarchy())) {
             final Formula formula = ((RolapCalculatedMember) member)
@@ -377,7 +378,7 @@ public class ScenarioImpl implements Scenario {
      * a cube has writeback enabled iff it has a dimension called "Scenario".)
      *
      * @param schema Schema
-     */
+ */
     public void register(RolapCatalog schema) {
         // Add a value to the [Scenario] dimension of every cube that has
         // writeback enabled.
@@ -402,7 +403,7 @@ public class ScenarioImpl implements Scenario {
      *
      * @param hierarchy Hierarchy
      * @return Whether hierarchy is the scenario hierarchy
-     */
+ */
     public static boolean isScenario(Hierarchy hierarchy) {
         return hierarchy.getName().equals("Scenario");
     }
@@ -413,13 +414,18 @@ public class ScenarioImpl implements Scenario {
      *
      * @param evaluator Evaluator
      * @return Number of atomic cells in the current cell
-     */
+ */
     private static double evaluateAtomicCellCount(RolapEvaluator evaluator) {
         final int savepoint = evaluator.savepoint();
         try {
             evaluator.setContext(
                 evaluator.getCube().getAtomicCellCountMeasure());
             final Object o = evaluator.evaluateCurrent();
+            if (o == NotLoaded.INSTANCE) {
+                // dirty batching pass whose results are discarded - the
+                // legacy Double(0) marker used to yield a count of 0 here
+                return 0;
+            }
             return ((Number) o).doubleValue();
         } finally {
             evaluator.restore(savepoint);
@@ -441,7 +447,7 @@ public class ScenarioImpl implements Scenario {
      * @param cube Cube
      * @param memberList Coordinate members of cell
      * @return Number of atomic cells in cell
-     */
+ */
     private static double computeAtomicCellCount(
         RolapCube cube, List<Member> memberList)
     {
@@ -491,7 +497,7 @@ public class ScenarioImpl implements Scenario {
      * has been called.
      *
      * @return Scenario member
-     */
+ */
     public Member getMember() {
         return member;
     }
@@ -507,7 +513,7 @@ public class ScenarioImpl implements Scenario {
      *
      * In future, a {@link ScenarioImpl} could be persisted by
      * serializing all {@code WritebackCell}s to a file.
-     */
+ */
     public static class WritebackCellImpl implements WritebackCell {
 
 
@@ -527,7 +533,7 @@ public class ScenarioImpl implements Scenario {
          * @param newValue New value
          * @param currentValue Current value
          * @param allocationPolicy Allocation policy
-         */
+ */
         WritebackCellImpl(
             RolapCube cube,
             List<Member> members,
@@ -597,7 +603,7 @@ public class ScenarioImpl implements Scenario {
          * override.
          *
          * @return Amount by which value has increased
-         */
+ */
         @Override
         public double getOffset() {
             return newValue - currentValue;
@@ -613,7 +619,7 @@ public class ScenarioImpl implements Scenario {
          * @param members Co-ordinates of another cell
          * @return Relation of this writeback cell to other co-ordinate, never
          * null
-         */
+ */
         @Override
         public WritebackCell.CellRelation getRelationTo(Member[] members) {
             int aboveCount = 0;
@@ -664,7 +670,7 @@ public class ScenarioImpl implements Scenario {
      * {@link Cell#setValue(Object, AllocationPolicy, Object...)},
      * and modifies the values of ancestors or descendants of such cells
      * according to the allocation policy.
-     */
+ */
     private static class ScenarioCalc extends AbstractProfilingNestedUnknownCalc {
         private final ScenarioImpl scenario;
 
@@ -673,7 +679,7 @@ public class ScenarioImpl implements Scenario {
          *
          * @param scenario Scenario whose writeback values should be substituted
          * for the values stored in the database.
-         */
+ */
         public ScenarioCalc(ScenarioImpl scenario) {
             super(ScalarType.INSTANCE);
             this.scenario = scenario;
@@ -683,7 +689,7 @@ public class ScenarioImpl implements Scenario {
          * Returns the Scenario this writeback cell belongs to.
          *
          * @return Scenario, never null
-         */
+ */
         private Scenario getScenario() {
             return scenario;
         }

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/CellValueBoundaryTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/CellValueBoundaryTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.eclipse.daanse.olap.api.result.ErrorValue;
+import org.eclipse.daanse.olap.api.result.NotLoaded;
+import org.eclipse.daanse.olap.api.result.NullValue;
+import org.eclipse.daanse.olap.api.result.ObjectValue;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link RolapAggregationManager#toCellValue}, the bridge from the
+ * object convention of the cache probe API ({@link NullValue#INSTANCE} for a
+ * stored NULL / Java {@code null} for "not in cache" / raw value otherwise)
+ * into the sealed {@code CellValue} protocol of the {@code CellReader}
+ * chain.
+ *
+ * <p>
+ * A NULL cell must surface as {@link NullValue} (empty) and never leak as an
+ * {@link ObjectValue} carrying a placeholder — the interpreter's
+ * {@code IsEmpty} would then report NULL cells as non-empty and diverge from
+ * the native SQL path.
+ */
+class CellValueBoundaryTest {
+
+    @Test
+    void absentCellYieldsTheRequestedAbsentState() {
+        assertSame(NullValue.INSTANCE,
+                RolapAggregationManager.toCellValue(null, NullValue.INSTANCE));
+        assertSame(NotLoaded.INSTANCE,
+                RolapAggregationManager.toCellValue(null, NotLoaded.INSTANCE));
+    }
+
+    @Test
+    void rawValueWrapsAsObjectValue() {
+        ObjectValue ov = assertInstanceOf(ObjectValue.class,
+                RolapAggregationManager.toCellValue(74748.0, NullValue.INSTANCE));
+        assertEquals(74748.0, ov.value());
+    }
+
+    @Test
+    void throwableWrapsAsErrorValue() {
+        RuntimeException failure = new RuntimeException("boom");
+        ErrorValue ev = assertInstanceOf(ErrorValue.class,
+                RolapAggregationManager.toCellValue(failure, NullValue.INSTANCE));
+        assertSame(failure, ev.cause());
+    }
+
+    @Test
+    void cellValueStatesPassThroughUnchanged() {
+        assertSame(NotLoaded.INSTANCE,
+                RolapAggregationManager.toCellValue(NotLoaded.INSTANCE, NullValue.INSTANCE));
+        assertSame(NullValue.INSTANCE,
+                RolapAggregationManager.toCellValue(NullValue.INSTANCE, NotLoaded.INSTANCE));
+    }
+}

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/agg/DenseSegmentBodyTestBase.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/agg/DenseSegmentBodyTestBase.java
@@ -47,7 +47,7 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
 {
 
   final V nonNull = createNonNullValue();
-  final V nullValue = createNullValue();
+  final V nullCellValue = createNullValue();
 
     @Test void getObjectNonNull() {
     T body = withOutAxes(nonNull);
@@ -55,7 +55,7 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
   }
 
     @Test void getObjectNull() {
-    T body = withOutAxes(nullValue);
+    T body = withOutAxes(nullCellValue);
         assertThat(body.getObject(0)).isNull();
   }
 
@@ -65,13 +65,13 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
   }
 
     @Test void getSizeHasNulls() {
-    T body = withOutAxes(nonNull, nullValue, nonNull);
+    T body = withOutAxes(nonNull, nullCellValue, nonNull);
         assertThat(body.getSize()).isEqualTo(3);
         assertThat(body.getEffectiveSize()).isEqualTo(2);
   }
 
     @Test void getSizeOnlyNulls() {
-    T body = withOutAxes(nullValue, nullValue, nullValue);
+    T body = withOutAxes(nullCellValue, nullCellValue, nullCellValue);
         assertThat(body.getSize()).isEqualTo(3);
         assertThat(body.getEffectiveSize()).isEqualTo(0);
   }
@@ -99,7 +99,7 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
     SortedSet<Comparable> axis2 = new TreeSet<>(asList(3));
     List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
         of(axis1, false), of(axis2, false));
-    T body = withAxes(axes, nonNull, nullValue, nonNull, nullValue, nonNull);
+    T body = withAxes(axes, nonNull, nullCellValue, nonNull, nullCellValue, nonNull);
     assertValuesMapIsCorrect(body, 3);
   }
 
@@ -109,7 +109,7 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
     List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
         of(axis1, false), of(axis2, true));
     T body = withAxes(
-        axes, nonNull, nullValue, nonNull, nullValue, nonNull, nonNull);
+        axes, nonNull, nullCellValue, nonNull, nullCellValue, nonNull, nonNull);
     assertValuesMapIsCorrect(body, 4);
   }
 
@@ -118,7 +118,7 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
     SortedSet<Comparable> axis2 = new TreeSet<>(asList(3));
     List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
         of(axis1, false), of(axis2, false));
-    T body = withAxes(axes, nullValue, nullValue);
+    T body = withAxes(axes, nullCellValue, nullCellValue);
     assertValuesMapIsCorrect(body, 0);
   }
 
@@ -127,7 +127,7 @@ abstract class DenseSegmentBodyTestBase<T extends AbstractSegmentBody, V>
     SortedSet<Comparable> axis2 = new TreeSet<>(asList(3));
     List<Pair<SortedSet<Comparable>, Boolean>> axes = asList(
         of(axis1, false), of(axis2, true));
-    T body = withAxes(axes, nullValue, nullValue);
+    T body = withAxes(axes, nullCellValue, nullCellValue);
     assertValuesMapIsCorrect(body, 0);
   }
 

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/BatchLoadTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/BatchLoadTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.daanse.olap.api.result.Cell;
+import org.eclipse.daanse.olap.api.result.Result;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterization of the load protocol (cache-miss, batch load,
+ * re-evaluation): a query touching many cells must return identical
+ * values on the first execution (cache-miss, dirty evaluation discarded and
+ * re-run after the batch load) and on the second execution (cache-hit). This
+ * freezes the batch/re-evaluation protocol externally, including NULL cells.
+ */
+class BatchLoadTest {
+
+    private static final String MDX = """
+            SELECT {[Measures].[ValSum], [Measures].[ValMin], [Measures].[ValMax], [Measures].[ValAvg],
+                    [Measures].[DecSum]} ON COLUMNS,
+                   [KeyDim].[KeyHierarchy].[KeyLevel].Members ON ROWS
+            FROM [NullSemantics]
+            """;
+
+    @Test
+    void cacheMissAndCacheHitReturnIdenticalCells() throws Exception {
+        // First execution: cache miss, cells resolved via the batch loader.
+        Result first = NullSemanticsFixture.execute(MDX);
+        // Second execution (fresh parse): served from the segment cache.
+        Result second = NullSemanticsFixture.execute(MDX);
+
+        int columns = first.getAxes()[0].getPositions().size();
+        int rows = first.getAxes()[1].getPositions().size();
+        assertEquals(5, columns);
+        assertEquals(5, rows);
+        assertEquals(columns, second.getAxes()[0].getPositions().size());
+        assertEquals(rows, second.getAxes()[1].getPositions().size());
+
+        for (int row = 0; row < rows; row++) {
+            for (int col = 0; col < columns; col++) {
+                int[] pos = { col, row };
+                Cell a = first.getCell(pos);
+                Cell b = second.getCell(pos);
+                String at = "cell [" + col + "," + row + "]";
+                assertEquals(a.isNull(), b.isNull(), at + " isNull");
+                assertEquals(a.getValue(), b.getValue(), at + " value");
+                assertEquals(a.getFormattedValue(), b.getFormattedValue(), at + " formatted value");
+            }
+        }
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/BooleanLevelMemberLookupTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/BooleanLevelMemberLookupTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.sql.PreparedStatement;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.testkit.database.DatabaseLayer;
+import org.eclipse.daanse.cwm.util.resource.relational.SqlSimpleTypes;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
+import org.eclipse.daanse.olap.api.Context;
+import org.eclipse.daanse.olap.api.connection.Connection;
+import org.eclipse.daanse.olap.api.result.Result;
+import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
+import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
+import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.TableSource;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.MeasureGroup;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.SumMeasure;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.StandardDimension;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
+import org.eclipse.daanse.rolap.mapping.model.provider.CatalogMappingSupplier;
+import org.eclipse.daanse.rolap.testkit.core.TestContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for the mondrian TCK failure
+ * {@code SegmentBuilderTest#testSegmentCreationForBoolean_True/_False}
+ * (null/decimal-semantics initiative): members of a BOOLEAN level
+ * ({@code [true]} / {@code [false]}) must be resolvable by name in a slicer.
+ */
+class BooleanLevelMemberLookupTest {
+
+    private static Connection connection;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        ActiveDatabase db = DatabaseProvider.selected().activate("BooleanLevelMemberLookup");
+        BoolCatalogSupplier supplier = new BoolCatalogSupplier();
+        DatabaseLayer.apply(db.dataSource(), db.dialect(), supplier.schema());
+        insertRows(db.dataSource());
+        TestContext ctx = new TestContext(db.dataSource(), db.dialect(), supplier);
+        connection = ((Context<?>) ctx).getConnectionWithDefaultRole();
+    }
+
+    private static void insertRows(DataSource dataSource) throws Exception {
+        try (java.sql.Connection jdbc = dataSource.getConnection();
+                PreparedStatement ps = jdbc.prepareStatement(
+                        "insert into \"STOREB\" (\"NAME\", \"COFFEE\", \"SQFT\") values (?, ?, ?)")) {
+            insert(ps, "a", true, 10.0);
+            insert(ps, "b", false, 20.0);
+            insert(ps, "c", true, 30.0);
+        }
+    }
+
+    private static void insert(PreparedStatement ps, String name, boolean coffee, double sqft) throws Exception {
+        ps.setString(1, name);
+        ps.setBoolean(2, coffee);
+        ps.setDouble(3, sqft);
+        ps.executeUpdate();
+    }
+
+    /**
+     * The key of a BOOLEAN-typed level arrives as a Number (0/1) through the
+     * dialect's INT accessor; the member name must still be true/false, not
+     * 0/1 (main fix d2e6497, RolapMemberBase.keyToName).
+ */
+    @Test
+    void booleanLevelMembersAreNamedTrueFalse() throws Exception {
+        Result result = execute("""
+                SELECT [CoffeeDim].[CoffeeHierarchy].[CoffeeLevel].members ON COLUMNS
+                FROM [BoolCube]
+                """);
+        List<String> names = result.getAxes()[0].getPositions().stream()
+                .map(p -> p.get(0).getName())
+                .sorted()
+                .toList();
+        assertEquals(List.of("false", "true"), names);
+    }
+
+    /**
+     * The TCK failure was a FailedToParseQueryException: '[Has coffee bar].[true]'
+     * not found. Parsing resolves the slicer member, so a successful parse pins
+     * the by-name lookup. (Execution is not asserted here: with the key arriving
+     * as 0/1 through the INT accessor the segment predicate is rendered
+     * numerically, which H2's strict BOOLEAN comparison rejects - a
+     * dialect-specific mismatch outside this regression; the duckdb TCK covers
+     * the end-to-end path.)
+ */
+    @Test
+    void booleanTrueMemberResolvesInSlicer() throws Exception {
+        assertNotNull(connection.parseQuery("""
+                SELECT {[Measures].[SqftSum]} ON COLUMNS
+                FROM [BoolCube]
+                WHERE [CoffeeDim].[true]
+                """));
+    }
+
+    @Test
+    void booleanFalseMemberResolvesInSlicer() throws Exception {
+        assertNotNull(connection.parseQuery("""
+                SELECT {[Measures].[SqftSum]} ON COLUMNS
+                FROM [BoolCube]
+                WHERE [CoffeeDim].[false]
+                """));
+    }
+
+    private static Result execute(String mdx) throws Exception {
+        return connection.execute(connection.parseQuery(mdx));
+    }
+
+    /** Minimal catalog: fact table with a BOOLEAN dimension level. */
+    static class BoolCatalogSupplier implements CatalogMappingSupplier {
+
+        private final Schema databaseSchema;
+        private final Catalog catalog;
+
+        BoolCatalogSupplier() {
+            RelationalFactory rf = RelationalFactory.eINSTANCE;
+
+            Column nameColumn = rf.createColumn();
+            nameColumn.setName("NAME");
+            nameColumn.setType(SqlSimpleTypes.varcharType(20));
+
+            Column coffeeColumn = rf.createColumn();
+            coffeeColumn.setName("COFFEE");
+            coffeeColumn.setType(SqlSimpleTypes.Sql99.booleanType());
+
+            Column sqftColumn = rf.createColumn();
+            sqftColumn.setName("SQFT");
+            sqftColumn.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+
+            Table table = rf.createTable();
+            table.setName("STOREB");
+            table.getFeature().addAll(List.of(nameColumn, coffeeColumn, sqftColumn));
+
+            databaseSchema = rf.createSchema();
+            databaseSchema.getOwnedElement().add(table);
+
+            TableSource query = SourceFactory.eINSTANCE.createTableSource();
+            query.setTable(table);
+
+            SumMeasure sqftSum = MeasureFactory.eINSTANCE.createSumMeasure();
+            sqftSum.setName("SqftSum");
+            sqftSum.setColumn(sqftColumn);
+
+            MeasureGroup measureGroup = CubeFactory.eINSTANCE.createMeasureGroup();
+            measureGroup.getMeasures().add(sqftSum);
+
+            Level level = LevelFactory.eINSTANCE.createLevel();
+            level.setName("CoffeeLevel");
+            level.setColumn(coffeeColumn);
+            level.setUniqueMembers(true);
+            level.setColumnType(ColumnInternalDataType.BOOLEAN);
+
+            ExplicitHierarchy hierarchy = HierarchyFactory.eINSTANCE.createExplicitHierarchy();
+            hierarchy.setName("CoffeeHierarchy");
+            hierarchy.setPrimaryKey(coffeeColumn);
+            hierarchy.setSource(query);
+            hierarchy.getLevels().add(level);
+
+            StandardDimension dimension = DimensionFactory.eINSTANCE.createStandardDimension();
+            dimension.setName("CoffeeDim");
+            dimension.getHierarchies().add(hierarchy);
+
+            DimensionConnector dimensionConnector = DimensionFactory.eINSTANCE.createDimensionConnector();
+            dimensionConnector.setDimension(dimension);
+
+            PhysicalCube cube = CubeFactory.eINSTANCE.createPhysicalCube();
+            cube.setName("BoolCube");
+            cube.setSource(query);
+            cube.getMeasureGroups().add(measureGroup);
+            cube.getDimensionConnectors().add(dimensionConnector);
+
+            catalog = CatalogFactory.eINSTANCE.createCatalog();
+            catalog.setName("BoolCatalog");
+            catalog.getDbschemas().add(databaseSchema);
+            catalog.getCubes().add(cube);
+        }
+
+        Schema schema() {
+            return databaseSchema;
+        }
+
+        @Override
+        public Catalog get() {
+            return catalog;
+        }
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/DecimalPrecisionRoundtripTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/DecimalPrecisionRoundtripTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.math.BigDecimal;
+
+import org.eclipse.daanse.olap.api.result.Cell;
+import org.eclipse.daanse.olap.api.result.Result;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * DECIMAL(19,4) roundtrip: fact column DEC_VAL holds exact decimals whose sum
+ * (112345678901234.5682) is not representable as a double. TODAY the engine
+ * narrows the values to double, so the aggregate visibly loses the 4-decimal
+ * precision.
+ */
+class DecimalPrecisionRoundtripTest {
+
+    private static final String MDX = """
+            SELECT {[Measures].[DecSum]} ON COLUMNS
+            FROM [NullSemantics]
+            """;
+
+    /** Exact BigDecimal sum of the DEC_VAL column: 112345678901234.5682. */
+    private static BigDecimal exactSum() {
+        return NullSemanticsFixture.DEC_VALUES.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Target behavior with the decimal lane: Sum over a DECIMAL(19,4) column
+     * equals the exact BigDecimal sum of the column values.
+ */
+    @Test
+    @Disabled("Sum over DECIMAL(19,4) is narrowed to double and loses the .5682 fraction."
+            + " An exact decimal lane was evaluated and deliberately not built;"
+            + " this documents the accepted double narrowing.")
+    void sumOverDecimalColumnIsExact() throws Exception {
+        Result result = NullSemanticsFixture.execute(MDX);
+        Cell cell = result.getCell(new int[] { 0 });
+        BigDecimal actual = new BigDecimal(String.valueOf(cell.getValue()));
+        assertEquals(0, exactSum().compareTo(actual),
+                "expected exact decimal sum " + exactSum() + " but was " + actual);
+    }
+
+    /**
+     * TODAY's behavior, kept under regression watch: the value arrives as a
+     * Double and equals the double-narrowed exact sum — 1.1234567890123456E14
+     * instead of 112345678901234.5682 (the .0082 tail is gone). Turn this
+     * around (and delete it) in when
+     * {@link #sumOverDecimalColumnIsExact()} is enabled.
+ */
+    @Test
+    void sumOverDecimalColumnLosesPrecisionToday() throws Exception {
+        Result result = NullSemanticsFixture.execute(MDX);
+        Cell cell = result.getCell(new int[] { 0 });
+        Object value = cell.getValue();
+        assertInstanceOf(Double.class, value, "TODAY the DECIMAL sum surfaces as a Double");
+
+        // Frozen observed value (== exactSum().doubleValue()):
+        assertEquals(Double.valueOf(1.1234567890123456E14), value);
+        assertEquals(exactSum().doubleValue(), ((Double) value).doubleValue());
+
+        // ... and it is demonstrably NOT the exact decimal sum:
+        assertNotEquals(0, exactSum().compareTo(new BigDecimal(((Double) value).doubleValue())),
+                "double-narrowed sum must differ from the exact decimal sum — precision was lost");
+    }
+
+    /**
+     * Same loss on a single cell: member A's DEC_VAL is 99999999999999.9999,
+     * which TODAY comes back as the double 1.0E14 — the fraction is entirely
+     * absorbed by the narrowing.
+ */
+    @Test
+    void singleDecimalCellLosesFractionToday() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[DecSum]} ON COLUMNS,
+                       {[KeyDim].[KeyHierarchy].[A]} ON ROWS
+                FROM [NullSemantics]
+                """);
+        Cell cell = result.getCell(new int[] { 0, 0 });
+        assertEquals(Double.valueOf(1.0E14), cell.getValue(),
+                "TODAY 99999999999999.9999 is reported as 1.0E14");
+        assertEquals("100,000,000,000,000", cell.getFormattedValue());
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/FilterNotIsEmptyQueryTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/FilterNotIsEmptyQueryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.eclipse.daanse.olap.api.result.Result;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The interpreter's {@code Filter(..., Not IsEmpty(measure))} must exclude
+ * NULL cells - including cells answered from the segment cache, where the
+ * object-storage NULL placeholder ({@code NullValue.INSTANCE}) must map to
+ * {@code NullValue}, not leak as a value
+ * ({@code RolapAggregationManager.toCellValue}).
+ */
+class FilterNotIsEmptyQueryTest {
+
+    @Test
+    void filterNotIsEmptyExcludesNullCells() throws Exception {
+        // Rows B and D have NULL ValSum; A, C, E have values.
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       Filter([KeyDim].[KeyHierarchy].[KeyLevel].Members,
+                              Not IsEmpty([Measures].[ValSum])) ON ROWS
+                FROM [NullSemantics]
+                """);
+        List<String> rows = NullSemanticsFixture.rowMemberNames(result);
+        assertEquals(List.of("A", "C", "E"), rows,
+                "Filter(Not IsEmpty) must drop the NULL cells B and D");
+    }
+
+    /** Same shape, but with warmed cache (second execution). */
+    @Test
+    void filterNotIsEmptyExcludesNullCellsWarmCache() throws Exception {
+        NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       [KeyDim].[KeyHierarchy].[KeyLevel].Members ON ROWS
+                FROM [NullSemantics]
+                """);
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       Filter([KeyDim].[KeyHierarchy].[KeyLevel].Members,
+                              Not IsEmpty([Measures].[ValSum])) ON ROWS
+                FROM [NullSemantics]
+                """);
+        List<String> rows = NullSemanticsFixture.rowMemberNames(result);
+        assertEquals(List.of("A", "C", "E"), rows,
+                "Filter(Not IsEmpty) must drop the NULL cells B and D (warm cache)");
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullArithmeticQueryTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullArithmeticQueryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.daanse.olap.api.result.Cell;
+import org.eclipse.daanse.olap.api.result.Result;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * characterization: TODAY's arithmetic with an MDX NULL calculated
+ * member. Freezes the
+ * MSAS-compatible rules {@code null + 1 = 1}, {@code null * x = null},
+ * {@code x / null = +Infinity}.
+ */
+class NullArithmeticQueryTest {
+
+    private static Result result;
+
+    @BeforeAll
+    static void executeQuery() throws Exception {
+        result = NullSemanticsFixture.execute("""
+                WITH MEMBER [Measures].[NullM] AS 'NULL'
+                     MEMBER [Measures].[NullPlusOne] AS '[Measures].[NullM] + 1'
+                     MEMBER [Measures].[NullTimesTwo] AS '[Measures].[NullM] * 2'
+                     MEMBER [Measures].[OneOverNull] AS '1 / [Measures].[NullM]'
+                     MEMBER [Measures].[IsEmptyNull] AS 'IsEmpty([Measures].[NullM])'
+                SELECT {[Measures].[NullM], [Measures].[NullPlusOne], [Measures].[NullTimesTwo],
+                        [Measures].[OneOverNull], [Measures].[IsEmptyNull]} ON COLUMNS
+                FROM [NullSemantics]
+                """);
+    }
+
+    @Test
+    void nullLiteralMemberIsNullCell() {
+        Cell cell = result.getCell(new int[] { 0 });
+        assertTrue(cell.isNull());
+        assertNull(cell.getValue(), "TODAY: getValue() of the NULL calculated member is Java null");
+        assertEquals("", cell.getFormattedValue());
+    }
+
+    @Test
+    void nullPlusOneIsOne() {
+        Cell cell = result.getCell(new int[] { 1 });
+        assertFalse(cell.isNull());
+        assertEquals(Double.valueOf(1.0), cell.getValue(), "NULL + 1 = 1 (NULL treated as 0 in addition)");
+    }
+
+    @Test
+    void nullTimesTwoIsNull() {
+        Cell cell = result.getCell(new int[] { 2 });
+        assertTrue(cell.isNull(), "NULL * 2 stays NULL (multiplication propagates NULL)");
+        assertNull(cell.getValue());
+    }
+
+    /**
+     * {@code 1 / NULL} yields +Infinity TODAY (MSAS default; the
+     * nullDenominatorProducesNull property is off). The raw value is
+     * {@code Double.POSITIVE_INFINITY} and it is rendered as "Infinity".
+ */
+    @Test
+    void oneDividedByNullIsPositiveInfinity() {
+        Cell cell = result.getCell(new int[] { 3 });
+        assertFalse(cell.isNull());
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), cell.getValue());
+        assertEquals("Infinity", cell.getFormattedValue());
+    }
+
+    @Test
+    void isEmptyOnNullMemberIsTrue() {
+        Cell cell = result.getCell(new int[] { 4 });
+        assertFalse(cell.isNull(), "the boolean result itself is a regular cell");
+        assertEquals(Boolean.TRUE, cell.getValue());
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullCellQueryTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullCellQueryTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.daanse.olap.api.result.Cell;
+import org.eclipse.daanse.olap.api.result.Result;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MDX-level behavior of NULL cells.
+ *
+ * <p>
+ * Fact rows B and D have {@code VAL = SQL NULL} (see
+ * {@link NullSemanticsFixture}).
+ */
+class NullCellQueryTest {
+
+    /**
+     * A cell backed by a SQL NULL: {@code isNull()} is true,
+     * {@code getValue()} returns Java {@code null} and the formatted value
+     * is the empty string.
+ */
+    @Test
+    void nullCellIsNullAndGetValueReturnsJavaNull() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       [KeyDim].[KeyHierarchy].[KeyLevel].Members ON ROWS
+                FROM [NullSemantics]
+                """);
+
+        int rowB = NullSemanticsFixture.rowIndexOf(result, "B");
+        Cell nullCell = result.getCell(new int[] { 0, rowB });
+        assertTrue(nullCell.isNull(), "SQL-NULL backed cell must report isNull()");
+        assertNull(nullCell.getValue(), "getValue() of a NULL cell is Java null");
+        assertEquals("", nullCell.getFormattedValue(), "NULL cell formats as empty string");
+
+        int rowA = NullSemanticsFixture.rowIndexOf(result, "A");
+        Cell valueCell = result.getCell(new int[] { 0, rowA });
+        assertFalse(valueCell.isNull());
+        assertEquals(Double.valueOf(10.5), valueCell.getValue());
+    }
+
+    /** {@code IsEmpty} on a stored measure: true for NULL cells, false otherwise. */
+    @Test
+    void isEmptyOnStoredMeasure() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                WITH MEMBER [Measures].[ValIsEmpty] AS 'IsEmpty([Measures].[ValSum])'
+                SELECT {[Measures].[ValIsEmpty]} ON COLUMNS,
+                       [KeyDim].[KeyHierarchy].[KeyLevel].Members ON ROWS
+                FROM [NullSemantics]
+                """);
+
+        assertEquals(Boolean.FALSE,
+                result.getCell(new int[] { 0, NullSemanticsFixture.rowIndexOf(result, "A") }).getValue());
+        assertEquals(Boolean.TRUE,
+                result.getCell(new int[] { 0, NullSemanticsFixture.rowIndexOf(result, "B") }).getValue());
+        assertEquals(Boolean.TRUE,
+                result.getCell(new int[] { 0, NullSemanticsFixture.rowIndexOf(result, "D") }).getValue());
+    }
+
+    /** {@code CoalesceEmpty(measure, 0)} replaces NULL cells with 0.0. */
+    @Test
+    void coalesceEmptyReplacesNullWithDefault() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                WITH MEMBER [Measures].[ValOrZero] AS 'CoalesceEmpty([Measures].[ValSum], 0)'
+                SELECT {[Measures].[ValOrZero]} ON COLUMNS,
+                       [KeyDim].[KeyHierarchy].[KeyLevel].Members ON ROWS
+                FROM [NullSemantics]
+                """);
+
+        Cell coalescedNull = result.getCell(new int[] { 0, NullSemanticsFixture.rowIndexOf(result, "B") });
+        assertFalse(coalescedNull.isNull());
+        assertEquals(Double.valueOf(0.0), coalescedNull.getValue());
+        assertEquals(Double.valueOf(20.25),
+                result.getCell(new int[] { 0, NullSemanticsFixture.rowIndexOf(result, "C") }).getValue());
+    }
+
+    /**
+     * Aggregates over the partially-NULL VAL column (10.5, NULL, 20.25, NULL,
+     * 5.0) ignore NULL rows: Sum/Min/Max as if the NULL rows did not exist,
+     * Avg divides by the count of non-NULL rows (3), not the row count (5).
+ */
+    @Test
+    void aggregatesIgnoreNullRows() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum], [Measures].[ValMin], [Measures].[ValMax],
+                        [Measures].[ValAvg]} ON COLUMNS
+                FROM [NullSemantics]
+                """);
+
+        assertEquals(Double.valueOf(35.75), result.getCell(new int[] { 0 }).getValue(), "Sum");
+        assertEquals(Double.valueOf(5.0), result.getCell(new int[] { 1 }).getValue(), "Min");
+        assertEquals(Double.valueOf(20.25), result.getCell(new int[] { 2 }).getValue(), "Max");
+        assertEquals(Double.valueOf(35.75 / 3.0), result.getCell(new int[] { 3 }).getValue(),
+                "Avg over 3 non-NULL rows");
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullOrderingQueryTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullOrderingQueryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.daanse.olap.api.result.Result;
+import org.junit.jupiter.api.Test;
+
+/**
+ * characterization: TODAY's placement of NULL cells in Order and
+ * TopCount. The
+ * engine's sort order is -Infinity &lt; NULL &lt; values &lt; NaN &lt;
+ * +Infinity, so NULLs come first ascending and last descending.
+ *
+ * <p>
+ * ValSum by member: A=10.5, B=NULL, C=20.25, D=NULL, E=5.0.
+ */
+class NullOrderingQueryTest {
+
+    @Test
+    void orderAscendingPutsNullsBeforeValues() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       Order([KeyDim].[KeyHierarchy].[KeyLevel].Members, [Measures].[ValSum], BASC) ON ROWS
+                FROM [NullSemantics]
+                """);
+
+        // NULL members first (stable in hierarchical order), then ascending values.
+        assertEquals(List.of("B", "D", "E", "A", "C"), NullSemanticsFixture.rowMemberNames(result));
+        assertTrue(result.getCell(new int[] { 0, 0 }).isNull());
+        assertTrue(result.getCell(new int[] { 0, 1 }).isNull());
+        assertEquals(Double.valueOf(5.0), result.getCell(new int[] { 0, 2 }).getValue());
+        assertEquals(Double.valueOf(10.5), result.getCell(new int[] { 0, 3 }).getValue());
+        assertEquals(Double.valueOf(20.25), result.getCell(new int[] { 0, 4 }).getValue());
+    }
+
+    @Test
+    void orderDescendingPutsNullsAfterValues() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       Order([KeyDim].[KeyHierarchy].[KeyLevel].Members, [Measures].[ValSum], BDESC) ON ROWS
+                FROM [NullSemantics]
+                """);
+
+        assertEquals(List.of("C", "A", "E", "B", "D"), NullSemanticsFixture.rowMemberNames(result));
+        assertEquals(Double.valueOf(20.25), result.getCell(new int[] { 0, 0 }).getValue());
+        assertTrue(result.getCell(new int[] { 0, 3 }).isNull());
+        assertTrue(result.getCell(new int[] { 0, 4 }).isNull());
+    }
+
+    /**
+     * TopCount ranks NULL cells below every value, so the top 3 are the three
+     * members with non-NULL VAL.
+ */
+    @Test
+    void topCountPrefersValuesOverNulls() throws Exception {
+        Result result = NullSemanticsFixture.execute("""
+                SELECT {[Measures].[ValSum]} ON COLUMNS,
+                       TopCount([KeyDim].[KeyHierarchy].[KeyLevel].Members, 3, [Measures].[ValSum]) ON ROWS
+                FROM [NullSemantics]
+                """);
+
+        assertEquals(List.of("C", "A", "E"), NullSemanticsFixture.rowMemberNames(result));
+        assertEquals(Double.valueOf(20.25), result.getCell(new int[] { 0, 0 }).getValue());
+        assertEquals(Double.valueOf(10.5), result.getCell(new int[] { 0, 1 }).getValue());
+        assertEquals(Double.valueOf(5.0), result.getCell(new int[] { 0, 2 }).getValue());
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullSemanticsCatalogSupplier.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullSemanticsCatalogSupplier.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import java.util.List;
+
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
+import org.eclipse.daanse.cwm.util.resource.relational.SqlSimpleTypes;
+import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
+import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
+import org.eclipse.daanse.rolap.mapping.model.database.source.TableSource;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.CubeFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.MeasureGroup;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.PhysicalCube;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.AvgMeasure;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MaxMeasure;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MeasureFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.MinMeasure;
+import org.eclipse.daanse.rolap.mapping.model.olap.cube.measure.SumMeasure;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionConnector;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.DimensionFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.StandardDimension;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.ExplicitHierarchy;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.HierarchyFactory;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level;
+import org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.LevelFactory;
+import org.eclipse.daanse.rolap.mapping.model.provider.CatalogMappingSupplier;
+
+/**
+ * Bespoke catalog for the NULL/decimal-semantics characterization
+ * tests.
+ *
+ * <p>
+ * One fact table {@code FACT(KEY VARCHAR, VAL DOUBLE,
+ * DEC_VAL DECIMAL(19,4))} plus a single-level KEY dimension so every fact row
+ * is addressable as an individual cell:
+ * <ul>
+ * <li>{@code VAL} — nullable double, exercises SQL-NULL cells,</li>
+ * <li>{@code DEC_VAL} — DECIMAL(19,4) values whose exact sum is not
+ * representable as a double (precision-roundtrip demo).</li>
+ * </ul>
+ */
+public class NullSemanticsCatalogSupplier implements CatalogMappingSupplier {
+
+    public static final String CATALOG_NAME = "NullSemanticsCatalog";
+    public static final String CUBE_NAME = "NullSemantics";
+
+    public static final String MEASURE_VAL_SUM = "ValSum";
+    public static final String MEASURE_VAL_MIN = "ValMin";
+    public static final String MEASURE_VAL_MAX = "ValMax";
+    public static final String MEASURE_VAL_AVG = "ValAvg";
+    public static final String MEASURE_DEC_SUM = "DecSum";
+
+    private final Schema databaseSchema;
+    private final Catalog catalog;
+
+    public NullSemanticsCatalogSupplier() {
+        RelationalFactory rf = RelationalFactory.eINSTANCE;
+
+        Column keyColumn = rf.createColumn();
+        keyColumn.setName("KEY");
+        keyColumn.setType(SqlSimpleTypes.varcharType(20));
+
+        Column valColumn = rf.createColumn();
+        valColumn.setName("VAL");
+        valColumn.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        // Explicitly nullable — SQL-NULL cells are the point of this catalog.
+        valColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
+
+        Column decValColumn = rf.createColumn();
+        decValColumn.setName("DEC_VAL");
+        decValColumn.setType(SqlSimpleTypes.decimalType(19, 4));
+
+        Table table = rf.createTable();
+        table.setName("FACT");
+        table.getFeature().addAll(List.of(keyColumn, valColumn, decValColumn));
+
+        databaseSchema = rf.createSchema();
+        databaseSchema.getOwnedElement().add(table);
+
+        TableSource query = SourceFactory.eINSTANCE.createTableSource();
+        query.setTable(table);
+
+        MeasureFactory mf = MeasureFactory.eINSTANCE;
+
+        SumMeasure valSum = mf.createSumMeasure();
+        valSum.setName(MEASURE_VAL_SUM);
+        valSum.setColumn(valColumn);
+
+        MinMeasure valMin = mf.createMinMeasure();
+        valMin.setName(MEASURE_VAL_MIN);
+        valMin.setColumn(valColumn);
+
+        MaxMeasure valMax = mf.createMaxMeasure();
+        valMax.setName(MEASURE_VAL_MAX);
+        valMax.setColumn(valColumn);
+
+        AvgMeasure valAvg = mf.createAvgMeasure();
+        valAvg.setName(MEASURE_VAL_AVG);
+        valAvg.setColumn(valColumn);
+
+        SumMeasure decSum = mf.createSumMeasure();
+        decSum.setName(MEASURE_DEC_SUM);
+        decSum.setColumn(decValColumn);
+
+        MeasureGroup measureGroup = CubeFactory.eINSTANCE.createMeasureGroup();
+        measureGroup.getMeasures().addAll(List.of(valSum, valMin, valMax, valAvg, decSum));
+
+        Level level = LevelFactory.eINSTANCE.createLevel();
+        level.setName("KeyLevel");
+        level.setColumn(keyColumn);
+
+        ExplicitHierarchy hierarchy = HierarchyFactory.eINSTANCE.createExplicitHierarchy();
+        hierarchy.setName("KeyHierarchy");
+        hierarchy.setPrimaryKey(keyColumn);
+        hierarchy.setSource(query);
+        hierarchy.getLevels().add(level);
+
+        StandardDimension dimension = DimensionFactory.eINSTANCE.createStandardDimension();
+        dimension.setName("KeyDim");
+        dimension.getHierarchies().add(hierarchy);
+
+        DimensionConnector dimensionConnector = DimensionFactory.eINSTANCE.createDimensionConnector();
+        dimensionConnector.setDimension(dimension);
+
+        PhysicalCube cube = CubeFactory.eINSTANCE.createPhysicalCube();
+        cube.setName(CUBE_NAME);
+        cube.setSource(query);
+        cube.getMeasureGroups().add(measureGroup);
+        cube.getDimensionConnectors().add(dimensionConnector);
+
+        catalog = CatalogFactory.eINSTANCE.createCatalog();
+        catalog.setName(CATALOG_NAME);
+        catalog.setDescription("NULL/decimal semantics characterization catalog");
+        catalog.getDbschemas().add(databaseSchema);
+        catalog.getCubes().add(cube);
+    }
+
+    /** The CWM database schema, for {@code DatabaseLayer.apply}. */
+    public Schema schema() {
+        return databaseSchema;
+    }
+
+    @Override
+    public Catalog get() {
+        return catalog;
+    }
+}

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullSemanticsFixture.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullSemanticsFixture.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   SmartCity Jena, Stefan Bischof - initial
+ */
+package org.eclipse.daanse.rolap.testkit.nullsemantics;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.Types;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.eclipse.daanse.cwm.testkit.database.DatabaseLayer;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
+import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
+import org.eclipse.daanse.olap.api.Context;
+import org.eclipse.daanse.olap.api.connection.Connection;
+import org.eclipse.daanse.olap.api.result.Position;
+import org.eclipse.daanse.olap.api.result.Result;
+import org.eclipse.daanse.rolap.testkit.core.TestContext;
+
+/**
+ * Shared, lazily-initialized test setup for the NULL/decimal-semantics
+ * characterization suite: an isolated testkit database with the
+ * {@link NullSemanticsCatalogSupplier} schema, five explicit fact rows
+ * (inserted via plain JDBC so SQL NULL and exact DECIMAL literals are under
+ * test control) and one OLAP connection.
+ *
+ * <p>
+ * Fact data (also mirrored as constants below):
+ *
+ * <pre>
+ * KEY | VAL   | DEC_VAL
+ * A   | 10.5  |  99999999999999.9999
+ * B   | NULL  |               0.0001
+ * C   | 20.25 |               0.0001
+ * D   | NULL  |               0.0003
+ * E   | 5.0   |  12345678901234.5678
+ * </pre>
+ */
+final class NullSemanticsFixture {
+
+    /** Exact DEC_VAL column values, for BigDecimal reference arithmetic. */
+    static final List<BigDecimal> DEC_VALUES = List.of(
+            new BigDecimal("99999999999999.9999"),
+            new BigDecimal("0.0001"),
+            new BigDecimal("0.0001"),
+            new BigDecimal("0.0003"),
+            new BigDecimal("12345678901234.5678"));
+
+    private static Connection connection;
+
+    private NullSemanticsFixture() {
+    }
+
+    static synchronized Connection connection() throws Exception {
+        if (connection == null) {
+            ActiveDatabase db = DatabaseProvider.selected().activate("NullSemanticsCharacterization");
+            NullSemanticsCatalogSupplier supplier = new NullSemanticsCatalogSupplier();
+            DatabaseLayer.apply(db.dataSource(), db.dialect(), supplier.schema());
+            insertFactRows(db.dataSource());
+            TestContext ctx = new TestContext(db.dataSource(), db.dialect(), supplier);
+            connection = ((Context<?>) ctx).getConnectionWithDefaultRole();
+        }
+        return connection;
+    }
+
+    /** Parses and executes {@code mdx} against the shared connection. */
+    static Result execute(String mdx) throws Exception {
+        Connection conn = connection();
+        return conn.execute(conn.parseQuery(mdx));
+    }
+
+    /** Index of the row axis position whose (last) member is named {@code memberName}. */
+    static int rowIndexOf(Result result, String memberName) {
+        List<Position> positions = result.getAxes()[1].getPositions();
+        for (int i = 0; i < positions.size(); i++) {
+            // Position extends List<Member>; getMembers() is not implemented here.
+            Position position = positions.get(i);
+            if (position.get(position.size() - 1).getName().equals(memberName)) {
+                return i;
+            }
+        }
+        throw new AssertionError("no row for member " + memberName + " in " + describeRows(result));
+    }
+
+    /** Member names on the row axis, in axis order. */
+    static List<String> rowMemberNames(Result result) {
+        return result.getAxes()[1].getPositions().stream()
+                .map(p -> p.get(p.size() - 1).getName())
+                .toList();
+    }
+
+    private static String describeRows(Result result) {
+        return String.join(", ", rowMemberNames(result));
+    }
+
+    private static void insertFactRows(DataSource dataSource) throws Exception {
+        try (java.sql.Connection jdbc = dataSource.getConnection();
+                PreparedStatement ps = jdbc.prepareStatement(
+                        "insert into \"FACT\" (\"KEY\", \"VAL\", \"DEC_VAL\") values (?, ?, ?)")) {
+            insert(ps, "A", 10.5, DEC_VALUES.get(0));
+            insert(ps, "B", null, DEC_VALUES.get(1));
+            insert(ps, "C", 20.25, DEC_VALUES.get(2));
+            insert(ps, "D", null, DEC_VALUES.get(3));
+            insert(ps, "E", 5.0, DEC_VALUES.get(4));
+        }
+    }
+
+    private static void insert(PreparedStatement ps, String key, Double val, BigDecimal decVal)
+            throws Exception {
+        ps.setString(1, key);
+        if (val == null) {
+            ps.setNull(2, Types.DOUBLE);
+        } else {
+            ps.setDouble(2, val);
+        }
+        ps.setBigDecimal(3, decVal);
+        ps.executeUpdate();
+    }
+}


### PR DESCRIPTION
Companion to the olap change that replaces the in-band NULL encodings (magic double for MDX NULL, literal Double(0) for not-yet-loaded cells) with explicit representations:

- The load path returns the non-numeric NotLoaded marker on cache miss; computing with it fails fast, and the discarded batching pass tolerates it explicitly (SortedListCalc, TopBottomPercentSum, ScenarioImpl). SumAggregator drops its in-band MIN_VALUE empty markers for null-initialized accumulators.
- Segment reads up to the result cells speak the sealed CellValue state type with exhaustive switches; two unwrap seams keep the layers above unchanged, and the cache probe API keeps the legacy object convention for external consumers. Errors wrap in ErrorValue at the store; RolapCell.isNull/isError are state checks. A runtime-computed Double equal to the legacy sentinel is a real value again.
- SumAggregator's fast path sums through the compensated accumulator.
- Null checks route through the central NullSemantics helpers, giving the NULL representation a single switch point.
