### PR TITLE
support extending olap interfaces for CSDL

### DIFF
--- a/core/src/main/java/org/eclipse/daanse/rolap/common/nativize/RolapNativeSet.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/nativize/RolapNativeSet.java
@@ -41,6 +41,7 @@ import org.eclipse.daanse.olap.api.access.Role;
 import org.eclipse.daanse.olap.api.calc.ResultStyle;
 import org.eclipse.daanse.olap.api.calc.tuple.TupleList;
 import org.eclipse.daanse.olap.api.catalog.CatalogReader;
+import org.eclipse.daanse.olap.api.element.HideMemberCondition;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
 import org.eclipse.daanse.olap.api.element.Level;
 import org.eclipse.daanse.olap.api.element.Member;
@@ -644,7 +645,7 @@ public abstract class RolapNativeSet extends RolapNative {
     private boolean isRaggedLevel( Level level ) {
       if ( level instanceof RolapLevel rolapLevel) {
         return rolapLevel.getHideMemberCondition()
-          != RolapLevel.HideMemberCondition.Never;
+          != HideMemberCondition.NEVER;
       }
       // don't know if it's ragged, so assume it is.
       // should not reach here

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapBaseCubeMeasure.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapBaseCubeMeasure.java
@@ -25,8 +25,10 @@
 
 package org.eclipse.daanse.rolap.element;
 
-import org.eclipse.daanse.sql.model.type.Datatype;
+import java.util.Optional;
+
 import org.eclipse.daanse.olap.api.Context;
+import org.eclipse.daanse.olap.api.DataTypeJdbc;
 import org.eclipse.daanse.olap.api.aggregator.Aggregator;
 import org.eclipse.daanse.olap.api.element.MetaData;
 import org.eclipse.daanse.olap.api.element.PhysicalCubeMeasure;
@@ -41,6 +43,7 @@ import org.eclipse.daanse.rolap.api.element.RolapMember;
 import org.eclipse.daanse.rolap.common.result.RolapResult;
 import org.eclipse.daanse.rolap.common.star.RolapSqlExpression;
 import org.eclipse.daanse.rolap.mapping.model.database.relational.ColumnInternalDataType;
+import org.eclipse.daanse.sql.model.type.Datatype;
 
 /**
  * Measure which is computed from a SQL column (or expression) and which is
@@ -203,6 +206,14 @@ public class RolapBaseCubeMeasure
 
     public Datatype getDatatype() {
         return toDialectDatatype(getPropertyValue(StandardProperty.DATATYPE.getName()));
+    }
+
+    @Override
+    public Optional<DataTypeJdbc> getDataType() {
+        if (!(getPropertyValue(StandardProperty.DATATYPE.getName()) instanceof String literal)) {
+            return Optional.empty();
+        }
+        return Optional.of(DataTypeJdbc.fromValue(literal));
     }
 
     /**

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapHierarchy.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapHierarchy.java
@@ -59,6 +59,7 @@ import org.eclipse.daanse.olap.api.calc.tuple.TupleListCalc;
 import org.eclipse.daanse.olap.api.catalog.CatalogReader;
 import org.eclipse.daanse.olap.api.element.Dimension;
 import org.eclipse.daanse.olap.api.element.DimensionType;
+import org.eclipse.daanse.olap.api.element.HideMemberCondition;
 import org.eclipse.daanse.olap.api.element.Hierarchy;
 import org.eclipse.daanse.olap.api.element.Level;
 import org.eclipse.daanse.olap.api.element.LevelType;
@@ -231,7 +232,7 @@ public class RolapHierarchy extends HierarchyBase {
                     RolapLevel.FLAG_ALL | RolapLevel.FLAG_UNIQUE,
                     null,
                     null,
-                    RolapLevel.HideMemberCondition.Never,
+                    HideMemberCondition.NEVER,
                     LevelType.REGULAR,
                     "",
                     OlapMetaDataBase.empty()));
@@ -260,7 +261,7 @@ public class RolapHierarchy extends HierarchyBase {
                 RolapLevel.FLAG_ALL | RolapLevel.FLAG_UNIQUE,
                 null,
                 null,
-                RolapLevel.HideMemberCondition.Never,
+                HideMemberCondition.NEVER,
                 LevelType.NULL,
                 "",
                 OlapMetaDataBase.empty());
@@ -348,7 +349,7 @@ public class RolapHierarchy extends HierarchyBase {
                 RolapLevel.FLAG_ALL | RolapLevel.FLAG_UNIQUE,
                 null,
                 null,
-                RolapLevel.HideMemberCondition.Never,
+                HideMemberCondition.NEVER,
                 LevelType.REGULAR, ALL_LEVEL_CARDINALITY,
                 OlapMetaDataBase.empty());
         allLevel.init(cubeDimensionMapping);
@@ -646,7 +647,7 @@ public class RolapHierarchy extends HierarchyBase {
                 0,
                 null,
                 null,
-                RolapLevel.HideMemberCondition.Never,
+                HideMemberCondition.NEVER,
                 LevelType.REGULAR,
                 "",
                 OlapMetaDataBase.empty());
@@ -1241,7 +1242,7 @@ public class RolapHierarchy extends HierarchyBase {
 	public boolean isRagged() {
         for (Level level : levels) {
             if (((RolapLevel) level).getHideMemberCondition()
-                != RolapLevel.HideMemberCondition.Never)
+                != HideMemberCondition.NEVER)
             {
                 return true;
             }

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapLevel.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapLevel.java
@@ -32,6 +32,7 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import java.sql.Types;
@@ -44,13 +45,16 @@ import org.eclipse.daanse.olap.api.agg.Segment;
 import org.eclipse.daanse.olap.api.catalog.CatalogReader;
 import org.eclipse.daanse.olap.api.element.Dimension;
 import org.eclipse.daanse.olap.api.element.DimensionType;
+import org.eclipse.daanse.olap.api.element.HideMemberCondition;
 import org.eclipse.daanse.olap.api.element.Level;
 import org.eclipse.daanse.olap.api.element.LevelType;
 import org.eclipse.daanse.olap.api.element.MatchType;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.eclipse.daanse.olap.api.element.MetaData;
 import org.eclipse.daanse.olap.api.element.OlapElement;
+import org.eclipse.daanse.olap.api.element.OrderByProperty;
 import org.eclipse.daanse.olap.api.element.Property;
+import org.eclipse.daanse.olap.api.element.SortDirection;
 import org.eclipse.daanse.olap.api.formatter.MemberPropertyFormatter;
 import org.eclipse.daanse.olap.api.query.NameSegment;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
@@ -65,6 +69,7 @@ import org.eclipse.daanse.olap.format.FormatterFactory;
 import org.eclipse.daanse.olap.query.component.IdImpl;
 import org.eclipse.daanse.rolap.api.element.RolapMember;
 import org.eclipse.daanse.rolap.common.RolapUtil;
+import org.eclipse.daanse.rolap.common.sql.QueryTape.OrderBy;
 import org.eclipse.daanse.rolap.common.star.RolapSqlExpression;
 import org.eclipse.daanse.rolap.common.util.SqlExpressionResolver;
 import org.eclipse.daanse.rolap.common.util.LevelUtil;
@@ -401,6 +406,7 @@ public class RolapLevel extends LevelBase {
         return flags;
     }
 
+    @Override
     public HideMemberCondition getHideMemberCondition() {
         return hideMemberCondition;
     }
@@ -766,32 +772,6 @@ public class RolapLevel extends LevelBase {
         return internalType;
     }
 
-    /**
-     * Conditions under which a level's members may be hidden (thereby creating
-     * a <dfn>ragged hierarchy</dfn>).
-     */
-    public enum HideMemberCondition {
-        /** A member always appears. */
-        Never,
-
-        /** A member doesn't appear if its name is null or empty. */
-        IfBlankName,
-
-        /** A member appears unless its name matches its parent's. */
-        IfParentsName;
-
-        public static HideMemberCondition fromValue(String v) {
-            return Stream.of(HideMemberCondition.values())
-                .filter(e -> (e.toString().equalsIgnoreCase(v)))
-                .findFirst().orElse(Never);
-            // TODO:  care about fallback
-//                .orElseThrow(() -> new IllegalArgumentException(
-//                    new StringBuilder("HideMemberCondition enum Illegal argument ").append(v)
-//                        .toString())
-//                );
-        }
-    }
-
     public OlapElement lookupChild(CatalogReader schemaReader, Segment name) {
         return lookupChild(schemaReader, name, MatchType.EXACT);
     }
@@ -911,7 +891,7 @@ public class RolapLevel extends LevelBase {
         // is able to handle?
         if (getDepth() == getHierarchy().getLevels().size() - 1) {
             return switch (getHideMemberCondition()) {
-            case Never, IfBlankName -> false;
+            case NEVER, IF_BLANK_NAME -> false;
             default -> true;
             };
         }
@@ -944,4 +924,41 @@ public class RolapLevel extends LevelBase {
         return null;
     }
 
+    @Override
+    public Optional<OrderByProperty> getOrderByProperty() {
+        return resolveOrderBy(levelMapping, getProperties());
+    }
+
+    private static Optional<OrderByProperty> resolveOrderBy(
+            org.eclipse.daanse.rolap.mapping.model.olap.dimension.hierarchy.level.Level mappingLevel,
+            Property[] properties) {
+        var ordinalColumns = mappingLevel.getOrdinalColumns();
+        if (ordinalColumns == null || ordinalColumns.isEmpty()) {
+            return null;
+        }
+        if (ordinalColumns.size() > 1) {
+            LOGGER.warn("Level {}: {} ordinalColumns, only the first one will be considered "
+                    + "OrderBy depicted", mappingLevel.getName(), ordinalColumns.size());
+        }
+        var oc = ordinalColumns.get(0);
+        if (oc.getColumn() == null) {
+            return null;
+        }
+        for (var mp : mappingLevel.getMemberProperties()) {
+            if (mp.getColumn() == oc.getColumn()) {
+                for (Property p : properties) {
+                    if (p.getName().equals(mp.getName())) {
+                        return  Optional.of(new OrderByProperty(p, toDirection(oc.getDirection())));
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static SortDirection toDirection(
+            org.eclipse.daanse.rolap.mapping.model.database.relational.SortingDirection d) {
+        return d == org.eclipse.daanse.rolap.mapping.model.database.relational.SortingDirection.DESC ? SortDirection.DESC
+                                            : SortDirection.ASC;   // ASC/None → ASC
+    }
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapMemberBase.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapMemberBase.java
@@ -648,10 +648,10 @@ public class RolapMemberBase
 	public boolean isHidden() {
         final RolapLevel rolapLevel = getLevel();
         switch (rolapLevel.getHideMemberCondition()) {
-        case Never:
+        case NEVER:
             return false;
 
-        case IfBlankName:
+        case IF_BLANK_NAME:
         {
             // If the key value in the database is null, then we use
             // a special key value whose toString() is "null".
@@ -661,7 +661,7 @@ public class RolapMemberBase
         }
 
         //TODO:: IfParentsProperty and additional attribute that is by default the name, or a property that is switch
-        case IfParentsName:
+        case IF_PARENTS_NAME:
         {
             final Member parentMember = getParentMember();
             if (parentMember == null) {

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/member/NoFromQueryCountSqlTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/member/NoFromQueryCountSqlTest.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.daanse.sql.dialect.db.common.AnsiDialect;
 import org.eclipse.daanse.olap.api.Context;
 import org.eclipse.daanse.olap.api.element.Dimension;
+import org.eclipse.daanse.olap.api.element.HideMemberCondition;
 import org.eclipse.daanse.olap.api.element.LevelType;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
 import org.eclipse.daanse.olap.element.OlapMetaDataBase;
@@ -33,6 +33,7 @@ import org.eclipse.daanse.rolap.element.RolapColumn;
 import org.eclipse.daanse.rolap.element.RolapHierarchy;
 import org.eclipse.daanse.rolap.element.RolapLevel;
 import org.eclipse.daanse.rolap.element.RolapProperty;
+import org.eclipse.daanse.sql.dialect.db.common.AnsiDialect;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -93,7 +94,7 @@ class NoFromQueryCountSqlTest {
             SqlExpression keyExp, int flags) {
         return new RolapLevel(hierarchy, name, null, true, null, depth, keyExp, null, null,
                 null, null, null, null, RolapProperty.emptyArray, flags, null, null,
-                RolapLevel.HideMemberCondition.Never, LevelType.REGULAR, "",
+                HideMemberCondition.NEVER, LevelType.REGULAR, "",
                 OlapMetaDataBase.empty());
     }
 

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/querymap/LevelMemberCountSqlTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/querymap/LevelMemberCountSqlTest.java
@@ -21,11 +21,13 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.daanse.sql.dialect.db.common.AnsiDialect;
 import org.eclipse.daanse.olap.api.element.Dimension;
+import org.eclipse.daanse.olap.api.element.HideMemberCondition;
 import org.eclipse.daanse.olap.api.element.LevelType;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
 import org.eclipse.daanse.olap.element.OlapMetaDataBase;
+import org.eclipse.daanse.rolap.common.sqlbuild.CountQueries;
+import org.eclipse.daanse.rolap.common.sqlbuild.TupleSqlMapper;
 import org.eclipse.daanse.rolap.element.RolapColumn;
 import org.eclipse.daanse.rolap.element.RolapHierarchy;
 import org.eclipse.daanse.rolap.element.RolapLevel;
@@ -34,6 +36,7 @@ import org.eclipse.daanse.rolap.mapping.model.database.relational.DialectSqlView
 import org.eclipse.daanse.rolap.mapping.model.database.source.SqlSelectSource;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SqlStatement;
 import org.eclipse.daanse.rolap.mapping.model.database.source.TableSource;
+import org.eclipse.daanse.sql.dialect.db.common.AnsiDialect;
 import org.eclipse.daanse.sql.statement.render.DialectSqlRenderer;
 import org.eclipse.emf.common.util.BasicEList;
 import org.junit.jupiter.api.Test;
@@ -91,7 +94,7 @@ class LevelMemberCountSqlTest {
             SqlExpression keyExp, SqlExpression parentExp, int flags) {
         return new RolapLevel(hierarchy, name, null, true, null, depth, keyExp, null, null,
                 null, parentExp, null, null, RolapProperty.emptyArray, flags, null, null,
-                RolapLevel.HideMemberCondition.Never, LevelType.REGULAR, "",
+                HideMemberCondition.NEVER, LevelType.REGULAR, "",
                 OlapMetaDataBase.empty());
     }
 

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/sqlbuild/route/MemberChildrenRouterTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/sqlbuild/route/MemberChildrenRouterTest.java
@@ -21,8 +21,8 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.daanse.sql.dialect.db.common.AnsiDialect;
 import org.eclipse.daanse.olap.api.element.Dimension;
+import org.eclipse.daanse.olap.api.element.HideMemberCondition;
 import org.eclipse.daanse.olap.api.element.LevelType;
 import org.eclipse.daanse.olap.api.sql.SqlExpression;
 import org.eclipse.daanse.olap.element.OlapMetaDataBase;
@@ -34,6 +34,7 @@ import org.eclipse.daanse.rolap.element.RolapColumn;
 import org.eclipse.daanse.rolap.element.RolapHierarchy;
 import org.eclipse.daanse.rolap.element.RolapLevel;
 import org.eclipse.daanse.rolap.element.RolapProperty;
+import org.eclipse.daanse.sql.dialect.db.common.AnsiDialect;
 import org.eclipse.daanse.sql.statement.render.DialectSqlRenderer;
 import org.junit.jupiter.api.Test;
 
@@ -77,7 +78,7 @@ class MemberChildrenRouterTest {
         return new RolapLevel(hierarchy, name, null, true, null, depth, keyExp, null, null,
             null, null, null, null, RolapProperty.emptyArray, flags,
             org.eclipse.daanse.sql.model.type.Datatype.VARCHAR, null,
-            RolapLevel.HideMemberCondition.Never, LevelType.REGULAR, "",
+            HideMemberCondition.NEVER, LevelType.REGULAR, "",
             OlapMetaDataBase.empty());
     }
 


### PR DESCRIPTION
Signed-off-by: dbulahov <bulahovdenis@gmail.com>

### What does this PR do?

support extending olap interfaces for CSDL

interfaces api/src/main/java/org/eclipse/daanse/olap/api/element/Level.java and api/src/main/java/org/eclipse/daanse/ olap/api/element/StoredMeasure.java were extended. It were add Optional getDataType() to StoredMeasure and HideMemberCondition getHideMemberCondition() and Optional getOrderByProperty() to Level
It was added support for extended olap interfaces

https://github.com/eclipse-daanse/org.eclipse.daanse.olap/pull/133
