### PR TITLE
feat(function): collapse and name the Intersect/VisualTotals resolvers

### DIFF
--- a/core/src/main/java/org/eclipse/daanse/rolap/function/def/intersect/IntersectResolver.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/function/def/intersect/IntersectResolver.java
@@ -14,10 +14,10 @@
 package org.eclipse.daanse.rolap.function.def.intersect;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.daanse.mdx.model.api.expression.operation.FunctionOperationAtom;
 import org.eclipse.daanse.olap.api.DataType;
+import org.eclipse.daanse.olap.api.function.FunctionInterface;
 import org.eclipse.daanse.olap.api.function.FunctionMetaData;
 import org.eclipse.daanse.olap.api.function.FunctionResolver;
 import org.eclipse.daanse.olap.function.core.FunctionMetaDataR;
@@ -27,27 +27,23 @@ import org.osgi.service.component.annotations.Component;
 
 @Component(service = FunctionResolver.class)
 public class IntersectResolver extends AbstractFunctionDefinitionMultiResolver {
-    private static FunctionOperationAtom atom = new FunctionOperationAtom("Intersect");
-    private static List<String> reservedWords = List.of("ALL");
-    private static String DESCRIPTION = "Returns the intersection of two input sets, optionally retaining duplicates.";
-    private static FunctionParameterR[] xxy = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2"), new FunctionParameterR(DataType.SYMBOL, "All", Optional.of(reservedWords)) };
-    private static FunctionParameterR[] xx = { new FunctionParameterR(DataType.SET, "Set1"),
-            new FunctionParameterR(DataType.SET, "Set2") };
-    // {"fxxxy", "fxxx"}
+    private static final FunctionOperationAtom atom = new FunctionOperationAtom("Intersect");
+    private static final List<String> reservedWords = List.of("ALL");
+    private static final String DESCRIPTION = "Returns the intersection of two input sets, optionally retaining duplicates.";
 
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xxy);
-    private static FunctionMetaData functionMetaData2 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xx);
+    private static final FunctionMetaData functionMetaData = FunctionMetaDataR.of(atom, DESCRIPTION, DataType.SET,
+            FunctionParameterR.param(DataType.SET, "Set1"), //
+            FunctionParameterR.param(DataType.SET, "Set2"), //
+            FunctionParameterR.param(DataType.SYMBOL, "All_Flag").reserved("ALL").asOptional()
+                    .describedAs("ALL retains duplicates while intersecting."))
+            .interfaceName(FunctionInterface.FILTER);
 
     @Override
     public List<String> getReservedWords() {
         return reservedWords;
     }
 
-    
     public IntersectResolver() {
-        super(List.of(new IntersectFunDef(functionMetaData1), new IntersectFunDef(functionMetaData2)));
+        super(List.of(new IntersectFunDef(functionMetaData)));
     }
 }

--- a/core/src/main/java/org/eclipse/daanse/rolap/function/def/visualtotals/VisualTotalsResolver.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/function/def/visualtotals/VisualTotalsResolver.java
@@ -26,20 +26,15 @@ import org.osgi.service.component.annotations.Component;
 
 @Component(service = FunctionResolver.class)
 public class VisualTotalsResolver extends AbstractFunctionDefinitionMultiResolver {
-    private static FunctionOperationAtom atom = new FunctionOperationAtom("VisualTotals");
-    private static String DESCRIPTION = "Dynamically totals child members specified in a set using a pattern for the total label in the result set.";
-    private static FunctionParameterR[] x = { new FunctionParameterR(DataType.SET) };
-    private static FunctionParameterR[] xS = { new FunctionParameterR(DataType.SET), new FunctionParameterR(DataType.STRING, "Pattern") };
-    // {"fxx", "fxxS"}
+    private static final FunctionOperationAtom atom = new FunctionOperationAtom("VisualTotals");
+    private static final String DESCRIPTION = "Dynamically totals child members specified in a set using a pattern for the total label in the result set.";
 
-    private static FunctionMetaData functionMetaData = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, x);
-    private static FunctionMetaData functionMetaData1 = new FunctionMetaDataR(atom, DESCRIPTION,
-            DataType.SET, xS);
+    private static final FunctionMetaData functionMetaData = FunctionMetaDataR.of(atom, DESCRIPTION, DataType.SET,
+            FunctionParameterR.param(DataType.SET), //
+            FunctionParameterR.param(DataType.STRING, "Pattern").asOptional()
+                    .describedAs("Label pattern for the visual total member; * is replaced by the parent name."));
 
     public VisualTotalsResolver() {
-        super(List.of(new VisualTotalsFunDef(functionMetaData), new VisualTotalsFunDef(functionMetaData1)));
+        super(List.of(new VisualTotalsFunDef(functionMetaData)));
     }
-
-
 }


### PR DESCRIPTION
Both had one FunctionMetaData per arity; the optional trailing argument is now expressed on a single metadata (Intersect: All_Flag with reserved word ALL, VisualTotals: the Pattern string), so the discover reports one row per function instead of one per overload. Parameters get canonical names and descriptions, and Intersect is classified as FILTER.
