### PR TITLE
refactor: SqlSimpleTypes reads SQLSimpleTypes

### DIFF
--- a/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/JdbcSchema.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/common/aggmatcher/JdbcSchema.java
@@ -27,7 +27,7 @@ package org.eclipse.daanse.rolap.common.aggmatcher;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.text.MessageFormat;
@@ -744,7 +744,7 @@ public class JdbcSchema {
 				// Read the JDBC type code straight from the SQLSimpleType.typeNumber
 				// field; avoids JDBCType.valueOf(name) failing on SQL-99 spec names
 				// such as "CHARACTER VARYING" or "DOUBLE PRECISION".
-				int type = rdbType != null ? SqlSimpleTypes.jdbcType(rdbType) : 0;
+				int type = rdbType != null ? SQLSimpleTypes.jdbcType(rdbType) : 0;
 				Integer columnSize = rdbType == null ? 0 : (int) rdbType.getCharacterMaximumLength();
 				Integer decimalDigits = rdbType == null ? 0 : (int) rdbType.getNumericScale();
 				int numPrecRadix = rdbType == null ? 0 : (int) rdbType.getNumericPrecisionRadix();

--- a/core/src/main/java/org/eclipse/daanse/rolap/element/RolapLevel.java
+++ b/core/src/main/java/org/eclipse/daanse/rolap/element/RolapLevel.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
 import java.sql.Types;
 
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.SQLSimpleType;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.sql.model.type.BestFitColumnType;
 import org.eclipse.daanse.sql.model.type.Datatype;
 import org.eclipse.daanse.olap.api.agg.Segment;
@@ -553,7 +553,7 @@ public class RolapLevel extends LevelBase {
         // is stable, so we map through java.sql.Types.
         if (mappingLevel.getColumn() != null
                 && mappingLevel.getColumn().getType() instanceof SQLSimpleType st) {
-            return jdbcTypeToDatatype(SqlSimpleTypes.jdbcType(st));
+            return jdbcTypeToDatatype(SQLSimpleTypes.jdbcType(st));
         }
         return Datatype.NUMERIC;
     }
@@ -738,7 +738,7 @@ public class RolapLevel extends LevelBase {
     public Datatype getKeyColumnPhysicalDatatype() {
         if (levelMapping != null && levelMapping.getColumn() != null
                 && levelMapping.getColumn().getType() instanceof SQLSimpleType st) {
-            return jdbcTypeToDatatype(SqlSimpleTypes.jdbcType(st));
+            return jdbcTypeToDatatype(SQLSimpleTypes.jdbcType(st));
         }
         return null;
     }

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackMeasureTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/writeback/RolapWritebackMeasureTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.sql.model.type.Datatype;
 import org.eclipse.daanse.olap.api.element.Member;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ class RolapWritebackMeasureTest {
     @Test void carriesNumericDatatype() {
         Column column = mock(Column.class);
         when(column.getName()).thenReturn("AMOUNT");
-        when(column.getType()).thenReturn(SqlSimpleTypes.Sql99.integerType());
+        when(column.getType()).thenReturn(SQLSimpleTypes.Sql99.integerType());
 
         Member measure = mock(Member.class);
 
@@ -43,7 +43,7 @@ class RolapWritebackMeasureTest {
     @Test void carriesVarcharDatatypeForTextMeasures() {
         Column column = mock(Column.class);
         when(column.getName()).thenReturn("COMMENT");
-        when(column.getType()).thenReturn(SqlSimpleTypes.Sql99.varcharType());
+        when(column.getType()).thenReturn(SQLSimpleTypes.Sql99.varcharType());
         Member measure = mock(Member.class);
 
         RolapWritebackMeasure m = new RolapWritebackMeasure(measure, column, Datatype.VARCHAR);

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/writeback/ScenarioImplTextWritebackTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/writeback/ScenarioImplTextWritebackTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.sql.model.type.Datatype;
 import org.eclipse.daanse.olap.api.DataTypeJdbc;
 import org.eclipse.daanse.olap.api.element.Dimension;
@@ -51,15 +51,15 @@ class ScenarioImplTextWritebackTest {
         // ----- columns on the writeback table -----
         Column wbCategoryColumn = mock(Column.class);
         when(wbCategoryColumn.getName()).thenReturn("CATEGORY");
-        when(wbCategoryColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.integerType());
+        when(wbCategoryColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.integerType());
 
         Column wbAmountColumn = mock(Column.class);
         when(wbAmountColumn.getName()).thenReturn("AMOUNT");
-        when(wbAmountColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.integerType());
+        when(wbAmountColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.integerType());
 
         Column wbCommentColumn = mock(Column.class);
         when(wbCommentColumn.getName()).thenReturn("COMMENT");
-        when(wbCommentColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.varcharType());
+        when(wbCommentColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.varcharType());
 
         // ----- dimension + (unused) connector for the attribute -----
         Dimension categoryDim = mock(Dimension.class);
@@ -162,10 +162,10 @@ class ScenarioImplTextWritebackTest {
         // configured as the [All] level.
         Column wbCategoryColumn = mock(Column.class);
         when(wbCategoryColumn.getName()).thenReturn("CATEGORY");
-        when(wbCategoryColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.varcharType());
+        when(wbCategoryColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.varcharType());
         Column wbCommentColumn = mock(Column.class);
         when(wbCommentColumn.getName()).thenReturn("COMMENT");
-        when(wbCommentColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.varcharType());
+        when(wbCommentColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.varcharType());
 
         Dimension categoryDim = mock(Dimension.class);
         when(categoryDim.getName()).thenReturn("Category");
@@ -205,7 +205,7 @@ class ScenarioImplTextWritebackTest {
     @Test void noMatchingWritebackMeasure_noTextRowPushed() {
         Column wbAmountColumn = mock(Column.class);
         when(wbAmountColumn.getName()).thenReturn("AMOUNT");
-        when(wbAmountColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.integerType());
+        when(wbAmountColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.integerType());
 
         Member amountMember = mock(Member.class);
         when(amountMember.getUniqueName()).thenReturn("[Measures].[Amount]");
@@ -243,10 +243,10 @@ class ScenarioImplTextWritebackTest {
     private static ScenarioImpl pushTextRow(String dimensionName, String memberKey, String value) {
         Column wbCategoryColumn = mock(Column.class);
         when(wbCategoryColumn.getName()).thenReturn("CATEGORY");
-        when(wbCategoryColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.varcharType());
+        when(wbCategoryColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.varcharType());
         Column wbCommentColumn = mock(Column.class);
         when(wbCommentColumn.getName()).thenReturn("COMMENT");
-        when(wbCommentColumn.getType()).thenReturn(SqlSimpleTypes.Sql99.varcharType());
+        when(wbCommentColumn.getType()).thenReturn(SQLSimpleTypes.Sql99.varcharType());
 
         Dimension categoryDim = mock(Dimension.class);
         when(categoryDim.getName()).thenReturn(dimensionName);

--- a/core/src/test/java/org/eclipse/daanse/rolap/common/writeback/WritebackUtilNullOtherMeasureTest.java
+++ b/core/src/test/java/org/eclipse/daanse/rolap/common/writeback/WritebackUtilNullOtherMeasureTest.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Method;
 
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Column;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.sql.model.type.Datatype;
 import org.eclipse.daanse.olap.api.DataTypeJdbc;
 import org.eclipse.daanse.olap.api.element.Member;
@@ -45,7 +45,7 @@ class WritebackUtilNullOtherMeasureTest {
     void textMeasureGetsTypedNullVarcharEntry() throws Exception {
         Column commentColumn = RelationalFactory.eINSTANCE.createColumn();
         commentColumn.setName("COMMENT");
-        commentColumn.setType(SqlSimpleTypes.Sql99.varcharType());
+        commentColumn.setType(SQLSimpleTypes.Sql99.varcharType());
 
         RolapWritebackMeasure textMeasure = new RolapWritebackMeasure(
                 mock(Member.class), commentColumn, Datatype.VARCHAR);
@@ -60,7 +60,7 @@ class WritebackUtilNullOtherMeasureTest {
     void numericMeasureGetsTypedNullNumericEntry() throws Exception {
         Column priceColumn = RelationalFactory.eINSTANCE.createColumn();
         priceColumn.setName("PRICE");
-        priceColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        priceColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         RolapWritebackMeasure numericMeasure = new RolapWritebackMeasure(
                 mock(Member.class), priceColumn, Datatype.NUMERIC);
@@ -76,7 +76,7 @@ class WritebackUtilNullOtherMeasureTest {
         // INTEGER, DECIMAL, etc. all bind via the NUMERIC JDBC path.
         Column countColumn = RelationalFactory.eINSTANCE.createColumn();
         countColumn.setName("CNT");
-        countColumn.setType(SqlSimpleTypes.Sql99.integerType());
+        countColumn.setType(SQLSimpleTypes.Sql99.integerType());
 
         Member m = mock(Member.class);
         // Bypass the convenience ctor — set datatype to anything non-VARCHAR.

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/BooleanLevelMemberLookupTest.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/BooleanLevelMemberLookupTest.java
@@ -25,7 +25,7 @@ import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
 import org.eclipse.daanse.cwm.testkit.database.DatabaseLayer;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.jdbc.datasource.testkit.api.ActiveDatabase;
 import org.eclipse.daanse.jdbc.datasource.testkit.api.DatabaseProvider;
 import org.eclipse.daanse.olap.api.Context;
@@ -150,15 +150,15 @@ class BooleanLevelMemberLookupTest {
 
             Column nameColumn = rf.createColumn();
             nameColumn.setName("NAME");
-            nameColumn.setType(SqlSimpleTypes.varcharType(20));
+            nameColumn.setType(SQLSimpleTypes.varcharType(20));
 
             Column coffeeColumn = rf.createColumn();
             coffeeColumn.setName("COFFEE");
-            coffeeColumn.setType(SqlSimpleTypes.Sql99.booleanType());
+            coffeeColumn.setType(SQLSimpleTypes.Sql99.booleanType());
 
             Column sqftColumn = rf.createColumn();
             sqftColumn.setName("SQFT");
-            sqftColumn.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+            sqftColumn.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
 
             Table table = rf.createTable();
             table.setName("STOREB");

--- a/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullSemanticsCatalogSupplier.java
+++ b/testkit/core/src/test/java/org/eclipse/daanse/rolap/testkit/nullsemantics/NullSemanticsCatalogSupplier.java
@@ -19,7 +19,7 @@ import org.eclipse.daanse.cwm.model.cwm.resource.relational.RelationalFactory;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Schema;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.Table;
 import org.eclipse.daanse.cwm.model.cwm.resource.relational.enumerations.NullableType;
-import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SqlSimpleTypes;
+import org.eclipse.daanse.cwm.model.cwm.resource.relational.util.SQLSimpleTypes;
 import org.eclipse.daanse.rolap.mapping.model.catalog.Catalog;
 import org.eclipse.daanse.rolap.mapping.model.catalog.CatalogFactory;
 import org.eclipse.daanse.rolap.mapping.model.database.source.SourceFactory;
@@ -74,17 +74,17 @@ public class NullSemanticsCatalogSupplier implements CatalogMappingSupplier {
 
         Column keyColumn = rf.createColumn();
         keyColumn.setName("KEY");
-        keyColumn.setType(SqlSimpleTypes.varcharType(20));
+        keyColumn.setType(SQLSimpleTypes.varcharType(20));
 
         Column valColumn = rf.createColumn();
         valColumn.setName("VAL");
-        valColumn.setType(SqlSimpleTypes.Sql99.doublePrecisionType());
+        valColumn.setType(SQLSimpleTypes.Sql99.doublePrecisionType());
         // Explicitly nullable — SQL-NULL cells are the point of this catalog.
         valColumn.setIsNullable(NullableType.COLUMN_NULLABLE);
 
         Column decValColumn = rf.createColumn();
         decValColumn.setName("DEC_VAL");
-        decValColumn.setType(SqlSimpleTypes.decimalType(19, 4));
+        decValColumn.setType(SQLSimpleTypes.decimalType(19, 4));
 
         Table table = rf.createTable();
         table.setName("FACT");


### PR DESCRIPTION
Follows the cwm helper rename; no behaviour change.
